### PR TITLE
Revert "Travis: Set build matrix to have GOOS and GOARCH set."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: go
 go:
 - 1.5.1
 
-env:
-# Define build matrix
-- GOOS=linux GOARCH=amd64
-
 before_install:
 # Install code coverage / coveralls tooling
 - go get -u github.com/axw/gocov/gocov


### PR DESCRIPTION
This reverts commit 10823d5b79a68cc50d408c7c0a7824f95d309bd5.
