### PR TITLE
Travis: Specify region for codedeploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ deploy:
   deployment_group: mender-artifacts-dev
   bundle_type: tar
   skip_cleanup: true
+  region: eu-west-1
   on:
    repo: mendersoftware/artifacts
    branch: master


### PR DESCRIPTION
Seems that it can’t find application, perhaps uses incorrect region.
