### PR TITLE
MEN-303: Add setting IMAGE_TAG tag to docker image before pushing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,7 @@ after_success:
 before_deploy:
     # Master is always lastest
     - if [ ! -z "$TRAVIS_TAG" ]; then export IMAGE_TAG=$TRAVIS_TAG; else export IMAGE_TAG=$TRAVIS_BRANCH; fi
+    - docker tag $DOCKER_REPOSITORY $DOCKER_REPOSITORY:$IMAGE_TAG
 
     # Upload image to docker registry only on PUSH
     - docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD


### PR DESCRIPTION
Seems he can’t push image with a tag if the tag have not been assigned
to the image first.
