### PR TITLE
Allow optional 'endpoint' in aws config

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ const (
 	SettingAwsS3RegionDefault = "eu-west-1"
 	SettingAweS3Bucket        = SettingsAws + ".bucket"
 	SettingAwsS3BucketDefault = "mender-artifact-storage"
+	SettingAwsURI             = SettingsAws + ".uri"
 
 	SettingsAwsAuth      = SettingsAws + ".auth"
 	SettingAwsAuthKeyId  = SettingsAwsAuth + ".key"

--- a/resources/images/storage_filestorage.go
+++ b/resources/images/storage_filestorage.go
@@ -16,6 +16,7 @@ package images
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,10 +45,15 @@ type SimpleStorageService struct {
 
 // NewSimpleStorageServiceStatic create new S3 client model.
 // AWS authentication keys are automatically reloaded from env variables.
-func NewSimpleStorageServiceStatic(bucket, key, secret, region, token string) *SimpleStorageService {
+func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri string) *SimpleStorageService {
 
 	credentials := credentials.NewStaticCredentials(key, secret, token)
 	config := aws.NewConfig().WithCredentials(credentials).WithRegion(region)
+
+	if len(uri) > 0 {
+		sslDisabled := !strings.HasPrefix(uri, "https://")
+		config = config.WithDisableSSL(sslDisabled).WithEndpoint(uri)
+	}
 
 	sess := session.New(config)
 

--- a/routing.go
+++ b/routing.go
@@ -35,6 +35,7 @@ func SetupS3(c config.ConfigReader) images.FileStorager {
 			c.GetString(SettingAwsAuthSecret),
 			region,
 			c.GetString(SettingAwsAuthToken),
+			c.GetString(SettingAwsURI),
 		)
 	}
 


### PR DESCRIPTION
In order to use a FakeS3 server, I've added the option to specify an endpoint in the aws section of the config.
