### PR TITLE
deployments: allow non device ID to be a non UUIDv4 string

### DIFF
--- a/resources/deployments/deployment.go
+++ b/resources/deployments/deployment.go
@@ -52,7 +52,7 @@ func (c *DeploymentConstructor) Validate() error {
 	}
 
 	for _, id := range c.Devices {
-		if !govalidator.IsUUIDv4(id) {
+		if govalidator.IsNull(id) {
 			return ErrInvalidDeviceID
 		}
 	}

--- a/resources/deployments/deployment_external_test.go
+++ b/resources/deployments/deployment_external_test.go
@@ -66,8 +66,14 @@ func TestDeploymentConstructorValidate(t *testing.T) {
 		{
 			InputName:         StringToPointer("f826484e-1157-4109-af21-304e6d711560"),
 			InputArtifactName: StringToPointer("f826484e-1157-4109-af21-304e6d711560"),
-			InputDevices:      []string{"lala"},
+			InputDevices:      []string{""},
 			IsValid:           false,
+		},
+		{
+			InputName:         StringToPointer("f826484e-1157-4109-af21-304e6d711560"),
+			InputArtifactName: StringToPointer("f826484e-1157-4109-af21-304e6d711560"),
+			InputDevices:      []string{"lala"},
+			IsValid:           true,
 		},
 		{
 			InputName:         StringToPointer("f826484e-1157-4109-af21-304e6d711560"),


### PR DESCRIPTION
Do not attempt to validate device IDs as UUIDv4 strings

Signed-off-by: Maciej Borzecki maciej.borzecki@rndity.com
