### PR TITLE
Use AWS_URI and AWS authentication environment variables if they exist

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,7 +87,9 @@ aws:
                 # Environment variables:
                 # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
                 # If you're working with temporary security credentials,
-                # you can also keep the session token in AWS_SESSION_TOKEN
+                # you can also keep the session token in AWS_SESSION_TOKEN.
+                #
+                # If you're testing with a fake s3 environment, you can specify the uri endpoint with: AWS_URI
                 #
                 # Credentials File:
                 # Instead of keeping credentials in environment variables,

--- a/main.go
+++ b/main.go
@@ -55,6 +55,11 @@ func HandleConfigFile(filePath string) (config.ConfigReader, error) {
 	//Allow AWS URI endpoint to be set by environment variable
 	c.BindEnv(SettingAwsURI, "AWS_URI")
 
+	//Allow aws keyid, aws token, aws secret to be read by viper
+	c.BindEnv(SettingAwsAuthKeyId, "AWS_ACCESS_KEY_ID")
+	c.BindEnv(SettingAwsAuthSecret, "AWS_SECRET_ACCESS_KEY")
+	c.BindEnv(SettingAwsAuthToken, "AWS_SESSION_TOKEN")
+
 	c.SetConfigFile(filePath)
 
 	// Set default values for config

--- a/routing.go
+++ b/routing.go
@@ -36,8 +36,7 @@ func SetupS3(c config.ConfigReader) imagesModel.FileStorage {
 
 	bucket := c.GetString(SettingAweS3Bucket)
 	region := c.GetString(SettingAwsS3Region)
-
-	if c.IsSet(SettingsAwsAuth) {
+	if c.IsSet(SettingsAwsAuth) || (c.IsSet(SettingAwsAuthKeyId) && c.IsSet(SettingAwsAuthSecret) && c.IsSet(SettingAwsURI)) {
 		return s3.NewSimpleStorageServiceStatic(
 			bucket,
 			c.GetString(SettingAwsAuthKeyId),


### PR DESCRIPTION
Previously, if AWS_URI was set as an environment variable as well with AWS credentials, the AWS_URI variable would be ignored, since NewSimpleStorageServiceDefaults would be used. 

With this changed, if the standard aws-go environment variables are used along with AWS_URI, they will be respected

Signed-off-by: Greg Di Stefano <greg.distefano+github@gmail.com>
Signed-off-by: Greg Di Stefano greg@mender.io
