### PR TITLE
Actually return error when deployment logs are not found for a deployment/device

### DIFF
--- a/resources/deployments/mongo/device_deployment_logs.go
+++ b/resources/deployments/mongo/device_deployment_logs.go
@@ -82,7 +82,7 @@ func (d *DeviceDeploymentLogsStorage) GetDeviceDeploymentLog(deviceID, deploymen
 	if err := session.DB(DatabaseName).C(CollectionDeviceDeploymentLogs).
 		Find(query).One(&depl); err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, nil
+			return nil, err
 		}
 		return nil, err
 	}


### PR DESCRIPTION
When no deployment log is found a for a specific deployment/device, we should return an error, instead of nil.

Without this change, requesting a non-existing log file results in a crash.

Signed-off-by: Greg Di Stefano <greg.distefano+github@gmail.com>
