### PR TITLE
Return appropriate error when deployment logs are not found

### DIFF
--- a/resources/deployments/controller/controller_deployments.go
+++ b/resources/deployments/controller/controller_deployments.go
@@ -313,14 +313,15 @@ func (d *DeploymentsController) GetDeploymentLogForDevice(w rest.ResponseWriter,
 	devid := r.PathParam("devid")
 
 	depl, err := d.model.GetDeviceDeploymentLog(devid, did)
+
 	if err != nil {
-		if err == ErrModelDeploymentNotFound {
-			d.view.RenderError(w, err, http.StatusNotFound)
-		} else {
-			d.view.RenderError(w, err, http.StatusInternalServerError)
-		}
+		d.view.RenderError(w, err, http.StatusInternalServerError)
 		return
 	}
+
+    if depl == nil {
+        d.view.RenderErrorNotFound(w)
+    }
 
 	d.view.RenderDeploymentLog(w, *depl)
 }

--- a/resources/deployments/controller/controller_deployments_external_test.go
+++ b/resources/deployments/controller/controller_deployments_external_test.go
@@ -999,7 +999,7 @@ func TestControllerGetDeploymentLog(t *testing.T) {
 			InputModelMessages:      messages,
 
 			JSONResponseParams: h.JSONResponseParams{
-				OutputStatus:     http.StatusNotFound,
+				OutputStatus:     http.StatusInternalServerError,
 				OutputBodyObject: h.ErrorToErrStruct(errors.New("Deployment not found")),
 			},
 		},


### PR DESCRIPTION
When mgo.ErrNotFound is returned, and no DeploymentLog or error is returned, nil is passed to  [d.view.RenderDeploymentLog](https://github.com/mendersoftware/deployments/blob/master/resources/deployments/controller/controller_deployments.go#L325) and a crash occurs. 

Now, when a deployment log is not found, return a valid error message and send 404.

Signed-off-by: Greg Di Stefano <greg.distefano+github@gmail.com>
