### PR TITLE
deployment: bugfix for missing 'status' field in Deployment

### DIFF
--- a/resources/deployments/deployment.go
+++ b/resources/deployments/deployment.go
@@ -15,7 +15,6 @@
 package deployments
 
 import (
-	"encoding/json"
 	"errors"
 	"time"
 
@@ -107,23 +106,6 @@ func NewDeploymentFromConstructor(constructor *DeploymentConstructor) *Deploymen
 func (d *Deployment) Validate() error {
 	_, err := govalidator.ValidateStruct(d)
 	return err
-}
-
-// To be able to hide devices field, from API output provice custom marshaler
-func (d *Deployment) MarshalJSON() ([]byte, error) {
-
-	//Prevents from inheriting original MarshalJSON (if would, infinite loop)
-	type Alias Deployment
-
-	slim := struct {
-		*Alias
-		Devices []string `json:"devices,omitempty"`
-	}{
-		Alias:   (*Alias)(d),
-		Devices: nil,
-	}
-
-	return json.Marshal(&slim)
 }
 
 func (d *Deployment) IsInProgress() bool {


### PR DESCRIPTION
everything seems to be in place for 'status' to be returned, i.e.
the field is correctly defined and updated in the ApiDeploymentWrapper.

the culprit is the custom marshaller for Deployment - it's called when we serialize
the wrapper struct (embedding the Deployment). for some reason it does not serialize
the 'status' field; simply removing the marshaller 'fixes' the problem.

it's not clear why this happens - a poc on go playground exhibits the correct behavior
even with the marshaller present. the undesired beahvior is observed also in our
docker containers, and on local machines.

Issues: MEN-613

Signed-off-by: mchalczynski marcin.chalczynski@rndity.com
