### PR TITLE
device_deployment_log: relax 'messages' validation

### DIFF
--- a/resources/deployments/device_deployment_log.go
+++ b/resources/deployments/device_deployment_log.go
@@ -34,7 +34,7 @@ type DeploymentLog struct {
 	DeviceID     string `json:"-" valid:"required"`
 	DeploymentID string `json:"-" valid:"uuidv4,required"`
 
-	Messages []LogMessage `json:"messages" valid:"required"`
+	Messages []LogMessage `json:"messages" valid:"optional"`
 }
 
 var (

--- a/resources/deployments/model/deployments_external_test.go
+++ b/resources/deployments/model/deployments_external_test.go
@@ -115,7 +115,7 @@ func TestDeploymentModelImageUsedInActiveDeployment(t *testing.T) {
 		deviceDeploymentStorage := new(mocks.DeviceDeploymentStorage)
 		deviceDeploymentStorage.On("ExistAssignedImageWithIDAndStatuses", testCase.InputID, mock.AnythingOfType("[]string")).
 			Return(testCase.InputExistAssignedImageWithIDAndStatusesFound,
-			testCase.InputExistAssignedImageWithIDAndStatusesError)
+				testCase.InputExistAssignedImageWithIDAndStatusesError)
 
 		model := NewDeploymentModel(nil, nil, deviceDeploymentStorage, nil, nil)
 
@@ -169,7 +169,7 @@ func TestDeploymentModelImageUsedInDeployment(t *testing.T) {
 		deviceDeploymentStorage := new(mocks.DeviceDeploymentStorage)
 		deviceDeploymentStorage.On("ExistAssignedImageWithIDAndStatuses", testCase.InputID, mock.AnythingOfType("[]string")).
 			Return(testCase.InputImageUsedInDeploymentFound,
-			testCase.InputImageUsedInDeploymentError)
+				testCase.InputImageUsedInDeploymentError)
 
 		model := NewDeploymentModel(nil, nil, deviceDeploymentStorage, nil, nil)
 
@@ -248,7 +248,7 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 		deviceDeploymentStorage := new(mocks.DeviceDeploymentStorage)
 		deviceDeploymentStorage.On("FindOldestDeploymentForDeviceIDWithStatuses", testCase.InputID, mock.AnythingOfType("[]string")).
 			Return(testCase.InputOlderstDeviceDeployment,
-			testCase.InputOlderstDeviceDeploymentError)
+				testCase.InputOlderstDeviceDeploymentError)
 
 		imageLinker := new(mocks.GetRequester)
 		// Notice: force GetRequest to expect image id returned by FindOldestDeploymentForDeviceIDWithStatuses
@@ -647,7 +647,7 @@ func TestDeploymentModelSaveDeviceDeploymentLog(t *testing.T) {
 			InputModelError:    nil,
 			InputHasDeployment: true,
 
-			OutputError: errors.New("Invalid deployment log: DeploymentID: ID:234 does not validate as uuidv4;Messages: non zero value required;"),
+			OutputError: errors.New("Invalid deployment log: DeploymentID: ID:234 does not validate as uuidv4;"),
 		},
 		{
 			InputDeploymentID:  "f826484e-1157-4109-af21-304e6d711561",

--- a/resources/deployments/mongo/device_deployment_logs_test.go
+++ b/resources/deployments/mongo/device_deployment_logs_test.go
@@ -78,7 +78,7 @@ func TestSaveDeviceDeploymentLog(t *testing.T) {
 				DeploymentID: "30b3e62c-9ec2-4312-a7fa-cff24cc7397a",
 				Messages:     []deployments.LogMessage{},
 			},
-			OutputError: errors.New("Messages: non zero value required;"),
+			OutputError: nil,
 		},
 		{
 			InputDeviceDeploymentLog: deployments.DeploymentLog{


### PR DESCRIPTION
the server doesn't accept empty 'messages' list since the field is 'required'
(nil/empty slice is rejected); solution: make it 'optional'.

side effect: the server will now accept requests even if the 'messages' field is missing.
this is still persisted as 'messages: []' in mongo, so in case of a mistake, we're covered.

Issues: MEN-611

Signed-off-by: mchalczynski marcin.chalczynski@rndity.com
