### PR TITLE
deployments: use DeploymentLog instead of ApiDeploymentLog

### DIFF
--- a/resources/deployments/controller/controller_deployments.go
+++ b/resources/deployments/controller/controller_deployments.go
@@ -236,10 +236,6 @@ func (d *DeploymentsController) LookupDeployment(w rest.ResponseWriter, r *rest.
 	d.view.RenderSuccessGet(w, deps)
 }
 
-type ApiDeploymentLog struct {
-	Messages []deployments.LogMessage `json:"messages"`
-}
-
 func (d *DeploymentsController) PutDeploymentLogForDevice(w rest.ResponseWriter, r *rest.Request) {
 
 	did := r.PathParam("id")
@@ -252,7 +248,7 @@ func (d *DeploymentsController) PutDeploymentLogForDevice(w rest.ResponseWriter,
 
 	// reuse DeploymentLog, device and deployment IDs are ignored when
 	// (un-)marshalling DeploymentLog to/from JSON
-	var log ApiDeploymentLog
+	var log deployments.DeploymentLog
 
 	err = r.DecodeJsonPayload(&log)
 	if err != nil {

--- a/resources/deployments/controller/controller_deployments_external_test.go
+++ b/resources/deployments/controller/controller_deployments_external_test.go
@@ -818,7 +818,7 @@ func TestControllerPutDeploymentLog(t *testing.T) {
 		},
 		{
 			// all correct
-			InputBodyObject: &ApiDeploymentLog{
+			InputBodyObject: &deployments.DeploymentLog{
 				Messages: messages,
 			},
 			InputModelDeploymentID: "f826484e-1157-4109-af21-304e6d711560",
@@ -835,7 +835,7 @@ func TestControllerPutDeploymentLog(t *testing.T) {
 		},
 		{
 			// no authorization
-			InputBodyObject: &ApiDeploymentLog{
+			InputBodyObject: &deployments.DeploymentLog{
 				Messages: messages,
 			},
 			InputModelDeploymentID: "f826484e-1157-4109-af21-304e6d711560",
@@ -849,7 +849,7 @@ func TestControllerPutDeploymentLog(t *testing.T) {
 		},
 		{
 			// model error
-			InputBodyObject: &ApiDeploymentLog{
+			InputBodyObject: &deployments.DeploymentLog{
 				Messages: messages,
 			},
 			InputModelDeploymentID: "f826484e-1157-4109-af21-304e6d711560",
@@ -867,7 +867,7 @@ func TestControllerPutDeploymentLog(t *testing.T) {
 		},
 		{
 			// deployment not assigned to device
-			InputBodyObject: &ApiDeploymentLog{
+			InputBodyObject: &deployments.DeploymentLog{
 				Messages: messages,
 			},
 			InputModelDeploymentID: "f826484e-1157-4109-af21-304e6d711560",


### PR DESCRIPTION
DeploymentLog already has an unmarshaller which checks the 'messages' field.
This is missing from ApiDeploymentLog.

Issues: MEN-611

Signed-off-by: mchalczynski marcin.chalczynski@rndity.com
