### PR TITLE
Use inventory service directly, not through gateway.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,8 +58,8 @@ listen: :8080
 mongo-url: mongo-deployments
 
         # Public API gateway address
-        # Defaults to: "localhost:9080"
-mender-gateway: "localhost:9080"
+        # Defaults to: "http://mender-inventory:8080"
+mender-gateway: "http://mender-inventory:8080"
 
 aws:
                 # AWS region

--- a/integration/inventory.go
+++ b/integration/inventory.go
@@ -26,7 +26,7 @@ import (
 
 // Routes
 const (
-	DevicesInventory string = "/api/integrations/0.1/inventory/devices/%s"
+	DevicesInventory string = "/api/0.1.0/devices/%s"
 )
 
 type Attibute struct {


### PR DESCRIPTION
This will be consistent across all microservices.

Signed-off-by: Marcin Pasinski marcin.pasinski@mender.io
