### PR TITLE
Unify API error output

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -148,15 +148,19 @@ paths:
 
 definitions:
   Error:
-    description: Error descriptor
+    description: Error descriptor.
     type: object
     properties:
       error:
-        description: Description of the error
+        description: Description of the error.
+        type: string
+      request_id:
+        description: Request ID (same as in X-MEN-RequestID header).
         type: string
     example:
       application/json:
           error: "failed to decode device group data: JSON payload is empty"
+          request_id: "f7881e82-0492-49fb-b459-795654e7188a"
   DeploymentInstructions:
     type: object
     properties:

--- a/docs/integrations_api.yml
+++ b/docs/integrations_api.yml
@@ -392,15 +392,19 @@ paths:
 
 definitions:
   Error:
-    description: Error descriptor
+    description: Error descriptor.
     type: object
     properties:
       error:
-        description: Description of the error
+        description: Description of the error.
+        type: string
+      request_id:
+        description: Request ID (same as in X-MEN-RequestID header).
         type: string
     example:
       application/json:
           error: "failed to decode device group data: JSON payload is empty"
+          request_id: "f7881e82-0492-49fb-b459-795654e7188a"
   NewDeployment:
     type: object
     properties:

--- a/resources/deployments/controller/controller_deployments.go
+++ b/resources/deployments/controller/controller_deployments.go
@@ -49,13 +49,13 @@ func (d *DeploymentsController) PostDeployment(w rest.ResponseWriter, r *rest.Re
 
 	constructor, err := d.getDeploymentConstructorFromBody(r)
 	if err != nil {
-		d.view.RenderError(w, errors.Wrap(err, "Validating request body"), http.StatusBadRequest, l)
+		d.view.RenderError(w, r, errors.Wrap(err, "Validating request body"), http.StatusBadRequest, l)
 		return
 	}
 
 	id, err := d.model.CreateDeployment(constructor)
 	if err != nil {
-		d.view.RenderInternalError(w, err, l)
+		d.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
@@ -81,18 +81,18 @@ func (d *DeploymentsController) GetDeployment(w rest.ResponseWriter, r *rest.Req
 	id := r.PathParam("id")
 
 	if !govalidator.IsUUIDv4(id) {
-		d.view.RenderError(w, ErrIDNotUUIDv4, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, ErrIDNotUUIDv4, http.StatusBadRequest, l)
 		return
 	}
 
 	deployment, err := d.model.GetDeployment(id)
 	if err != nil {
-		d.view.RenderInternalError(w, err, l)
+		d.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
 	if deployment == nil {
-		d.view.RenderErrorNotFound(w, l)
+		d.view.RenderErrorNotFound(w, r, l)
 		return
 	}
 
@@ -105,18 +105,18 @@ func (d *DeploymentsController) GetDeploymentStats(w rest.ResponseWriter, r *res
 	id := r.PathParam("id")
 
 	if !govalidator.IsUUIDv4(id) {
-		d.view.RenderError(w, ErrIDNotUUIDv4, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, ErrIDNotUUIDv4, http.StatusBadRequest, l)
 		return
 	}
 
 	stats, err := d.model.GetDeploymentStats(id)
 	if err != nil {
-		d.view.RenderInternalError(w, err, l)
+		d.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
 	if stats == nil {
-		d.view.RenderErrorNotFound(w, l)
+		d.view.RenderErrorNotFound(w, r, l)
 		return
 	}
 
@@ -128,13 +128,13 @@ func (d *DeploymentsController) GetDeploymentForDevice(w rest.ResponseWriter, r 
 
 	idata, err := identity.ExtractIdentityFromHeaders(r.Header)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
 	deployment, err := d.model.GetDeploymentForDevice(idata.Subject)
 	if err != nil {
-		d.view.RenderInternalError(w, err, l)
+		d.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
@@ -153,7 +153,7 @@ func (d *DeploymentsController) PutDeploymentStatusForDevice(w rest.ResponseWrit
 
 	idata, err := identity.ExtractIdentityFromHeaders(r.Header)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
@@ -162,13 +162,13 @@ func (d *DeploymentsController) PutDeploymentStatusForDevice(w rest.ResponseWrit
 
 	err = r.DecodeJsonPayload(&report)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
 	status := report.Status
 	if err := d.model.UpdateDeviceDeploymentStatus(did, idata.Subject, status); err != nil {
-		d.view.RenderInternalError(w, err, l)
+		d.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
@@ -181,7 +181,7 @@ func (d *DeploymentsController) GetDeviceStatusesForDeployment(w rest.ResponseWr
 	did := r.PathParam("id")
 
 	if !govalidator.IsUUIDv4(did) {
-		d.view.RenderError(w, ErrIDNotUUIDv4, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, ErrIDNotUUIDv4, http.StatusBadRequest, l)
 		return
 	}
 
@@ -189,10 +189,10 @@ func (d *DeploymentsController) GetDeviceStatusesForDeployment(w rest.ResponseWr
 	if err != nil {
 		switch err {
 		case ErrModelDeploymentNotFound:
-			d.view.RenderError(w, err, http.StatusNotFound, l)
+			d.view.RenderError(w, r, err, http.StatusNotFound, l)
 			return
 		default:
-			d.view.RenderInternalError(w, ErrInternal, l)
+			d.view.RenderInternalError(w, r, ErrInternal, l)
 			return
 		}
 	}
@@ -232,13 +232,13 @@ func (d *DeploymentsController) LookupDeployment(w rest.ResponseWriter, r *rest.
 	query, err := ParseLookupQuery(r.URL.Query())
 
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
 	deps, err := d.model.LookupDeployment(query)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
@@ -252,7 +252,7 @@ func (d *DeploymentsController) PutDeploymentLogForDevice(w rest.ResponseWriter,
 
 	idata, err := identity.ExtractIdentityFromHeaders(r.Header)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
@@ -262,15 +262,15 @@ func (d *DeploymentsController) PutDeploymentLogForDevice(w rest.ResponseWriter,
 
 	err = r.DecodeJsonPayload(&log)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusBadRequest, l)
+		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
 	if err := d.model.SaveDeviceDeploymentLog(idata.Subject, did, log.Messages); err != nil {
 		if err == ErrModelDeploymentNotFound {
-			d.view.RenderError(w, err, http.StatusNotFound, l)
+			d.view.RenderError(w, r, err, http.StatusNotFound, l)
 		} else {
-			d.view.RenderInternalError(w, err, l)
+			d.view.RenderInternalError(w, r, err, l)
 		}
 		return
 	}
@@ -287,12 +287,12 @@ func (d *DeploymentsController) GetDeploymentLogForDevice(w rest.ResponseWriter,
 	depl, err := d.model.GetDeviceDeploymentLog(devid, did)
 
 	if err != nil {
-		d.view.RenderInternalError(w, err, l)
+		d.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
 	if depl == nil {
-		d.view.RenderErrorNotFound(w, l)
+		d.view.RenderErrorNotFound(w, r, l)
 		return
 	}
 

--- a/resources/deployments/controller/controller_deployments.go
+++ b/resources/deployments/controller/controller_deployments.go
@@ -55,7 +55,7 @@ func (d *DeploymentsController) PostDeployment(w rest.ResponseWriter, r *rest.Re
 
 	id, err := d.model.CreateDeployment(constructor)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusInternalServerError, l)
+		d.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -87,7 +87,7 @@ func (d *DeploymentsController) GetDeployment(w rest.ResponseWriter, r *rest.Req
 
 	deployment, err := d.model.GetDeployment(id)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusInternalServerError, l)
+		d.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -111,7 +111,7 @@ func (d *DeploymentsController) GetDeploymentStats(w rest.ResponseWriter, r *res
 
 	stats, err := d.model.GetDeploymentStats(id)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusInternalServerError, l)
+		d.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -134,7 +134,7 @@ func (d *DeploymentsController) GetDeploymentForDevice(w rest.ResponseWriter, r 
 
 	deployment, err := d.model.GetDeploymentForDevice(idata.Subject)
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusInternalServerError, l)
+		d.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -168,7 +168,7 @@ func (d *DeploymentsController) PutDeploymentStatusForDevice(w rest.ResponseWrit
 
 	status := report.Status
 	if err := d.model.UpdateDeviceDeploymentStatus(did, idata.Subject, status); err != nil {
-		d.view.RenderError(w, err, http.StatusInternalServerError, l)
+		d.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -192,7 +192,7 @@ func (d *DeploymentsController) GetDeviceStatusesForDeployment(w rest.ResponseWr
 			d.view.RenderError(w, err, http.StatusNotFound, l)
 			return
 		default:
-			d.view.RenderError(w, ErrInternal, http.StatusInternalServerError, l)
+			d.view.RenderInternalError(w, ErrInternal, l)
 			return
 		}
 	}
@@ -270,7 +270,7 @@ func (d *DeploymentsController) PutDeploymentLogForDevice(w rest.ResponseWriter,
 		if err == ErrModelDeploymentNotFound {
 			d.view.RenderError(w, err, http.StatusNotFound, l)
 		} else {
-			d.view.RenderError(w, err, http.StatusInternalServerError, l)
+			d.view.RenderInternalError(w, err, l)
 		}
 		return
 	}
@@ -287,7 +287,7 @@ func (d *DeploymentsController) GetDeploymentLogForDevice(w rest.ResponseWriter,
 	depl, err := d.model.GetDeviceDeploymentLog(devid, did)
 
 	if err != nil {
-		d.view.RenderError(w, err, http.StatusInternalServerError, l)
+		d.view.RenderInternalError(w, err, l)
 		return
 	}
 

--- a/resources/deployments/controller/controller_deployments_external_test.go
+++ b/resources/deployments/controller/controller_deployments_external_test.go
@@ -136,6 +136,7 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 		for k, v := range testCase.Headers {
 			req.Header.Set(k, v)
 		}
+		req.Header.Add(requestid.RequestIdHeader, "test")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
@@ -210,8 +211,9 @@ func TestControllerGetDeployment(t *testing.T) {
 
 		api := makeApi(router)
 
-		recorded := test.RunRequest(t, api.MakeHandler(),
-			test.MakeSimpleRequest("GET", "http://localhost/r/"+testCase.InputID, nil))
+		req := test.MakeSimpleRequest("GET", "http://localhost/r/"+testCase.InputID, nil)
+		req.Header.Add(requestid.RequestIdHeader, "test")
+		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
 	}
@@ -284,8 +286,9 @@ func TestControllerPostDeployment(t *testing.T) {
 
 		api := makeApi(router)
 
-		recorded := test.RunRequest(t, api.MakeHandler(),
-			test.MakeSimpleRequest("POST", "http://localhost/r", testCase.InputBodyObject))
+		req := test.MakeSimpleRequest("POST", "http://localhost/r", testCase.InputBodyObject)
+		req.Header.Add(requestid.RequestIdHeader, "test")
+		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
 	}
@@ -397,6 +400,7 @@ func TestControllerPutDeploymentStatus(t *testing.T) {
 		for k, v := range testCase.Headers {
 			req.Header.Set(k, v)
 		}
+		req.Header.Add(requestid.RequestIdHeader, "test")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
@@ -477,6 +481,7 @@ func TestControllerGetDeploymentStats(t *testing.T) {
 
 		req := test.MakeSimpleRequest("POST", "http://localhost/r/"+testCase.InputModelDeploymentID,
 			nil)
+		req.Header.Add(requestid.RequestIdHeader, "test")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
@@ -554,8 +559,9 @@ func TestControllerGetDeviceStatusesForDeployment(t *testing.T) {
 
 		api := makeApi(router)
 
-		recorded := test.RunRequest(t, api.MakeHandler(),
-			test.MakeSimpleRequest("GET", "http://localhost/r/"+tc.deploymentID, nil))
+		req := test.MakeSimpleRequest("GET", "http://localhost/r/"+tc.deploymentID, nil)
+		req.Header.Add(requestid.RequestIdHeader, "test")
+		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, tc.JSONResponseParams)
 	}
@@ -693,6 +699,7 @@ func TestControllerLookupDeployment(t *testing.T) {
 		u.RawQuery = q.Encode()
 		t.Logf("query: %s", u.String())
 		req := test.MakeSimpleRequest("GET", u.String(), nil)
+		req.Header.Add(requestid.RequestIdHeader, "test")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
@@ -919,6 +926,7 @@ func TestControllerPutDeploymentLog(t *testing.T) {
 		for k, v := range testCase.Headers {
 			req.Header.Set(k, v)
 		}
+		req.Header.Add(requestid.RequestIdHeader, "test")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
@@ -1043,6 +1051,7 @@ func TestControllerGetDeploymentLog(t *testing.T) {
 		req := test.MakeSimpleRequest("GET", "http://localhost/r/"+
 			testCase.InputModelDeploymentID+"/"+testCase.InputModelDeviceID,
 			nil)
+		req.Header.Add(requestid.RequestIdHeader, "test")
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
 		if testCase.JSONResponseParams.OutputStatus != http.StatusOK {
 			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)

--- a/resources/deployments/controller/controller_deployments_external_test.go
+++ b/resources/deployments/controller/controller_deployments_external_test.go
@@ -90,7 +90,7 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 			InputModelError: errors.New("model error"),
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("model error")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 			Headers: map[string]string{
 				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-1"}`),
@@ -166,7 +166,7 @@ func TestControllerGetDeployment(t *testing.T) {
 			InputModelError: errors.New("model error"),
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("model error")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 		},
 		{
@@ -252,7 +252,7 @@ func TestControllerPostDeployment(t *testing.T) {
 			InputModelError: errors.New("model error"),
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("model error")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 		},
 		{
@@ -364,7 +364,7 @@ func TestControllerPutDeploymentStatus(t *testing.T) {
 
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("model error")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 			Headers: map[string]string{
 				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-4"}`),
@@ -428,7 +428,7 @@ func TestControllerGetDeploymentStats(t *testing.T) {
 
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("storage issue")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 		},
 		{
@@ -531,7 +531,7 @@ func TestControllerGetDeviceStatusesForDeployment(t *testing.T) {
 		"unknown model error": {
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("Internal error")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 			deploymentID:  "30b3e62c-9ec2-4312-a7fa-cff24cc7397a",
 			modelStatuses: nil,
@@ -868,7 +868,7 @@ func TestControllerPutDeploymentLog(t *testing.T) {
 
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("model error")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 			Headers: map[string]string{
 				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-4"}`),
@@ -985,7 +985,7 @@ func TestControllerGetDeploymentLog(t *testing.T) {
 			InputModelMessages:     messages,
 
 			JSONResponseParams: h.JSONResponseParams{
-				OutputStatus:     http.StatusNoContent,
+				OutputStatus:     http.StatusOK,
 				OutputBodyObject: nil,
 			},
 			Body: `2006-01-02 22:04:05 +0000 UTC notice: foo
@@ -1003,7 +1003,7 @@ func TestControllerGetDeploymentLog(t *testing.T) {
 
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("model error")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 		},
 		{
@@ -1011,12 +1011,12 @@ func TestControllerGetDeploymentLog(t *testing.T) {
 			InputModelDeploymentLog: nil,
 			InputModelDeploymentID:  "f826484e-1157-4109-af21-304e6d711560",
 			InputModelDeviceID:      "device-id-5",
-			InputModelError:         ErrModelDeploymentNotFound,
+			InputModelError:         nil,
 			InputModelMessages:      messages,
 
 			JSONResponseParams: h.JSONResponseParams{
-				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("Deployment not found")),
+				OutputStatus:     http.StatusNotFound,
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("Resource not found")),
 			},
 		},
 	}
@@ -1044,7 +1044,7 @@ func TestControllerGetDeploymentLog(t *testing.T) {
 			testCase.InputModelDeploymentID+"/"+testCase.InputModelDeviceID,
 			nil)
 		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		if testCase.InputModelError != nil {
+		if testCase.JSONResponseParams.OutputStatus != http.StatusOK {
 			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
 		} else {
 			assert.Equal(t, testCase.Body, recorded.Recorder.Body.String())

--- a/resources/deployments/controller/rest_view.go
+++ b/resources/deployments/controller/rest_view.go
@@ -25,8 +25,8 @@ type RESTView interface {
 	RenderSuccessPost(w rest.ResponseWriter, r *rest.Request, id string)
 	RenderSuccessGet(w rest.ResponseWriter, object interface{})
 	RenderEmptySuccessResponse(w rest.ResponseWriter)
-	RenderError(w rest.ResponseWriter, err error, status int, l *log.Logger)
-	RenderInternalError(w rest.ResponseWriter, err error, l *log.Logger)
-	RenderErrorNotFound(w rest.ResponseWriter, l *log.Logger)
+	RenderError(w rest.ResponseWriter, r *rest.Request, err error, status int, l *log.Logger)
+	RenderInternalError(w rest.ResponseWriter, r *rest.Request, err error, l *log.Logger)
+	RenderErrorNotFound(w rest.ResponseWriter, r *rest.Request, l *log.Logger)
 	RenderDeploymentLog(w rest.ResponseWriter, dlog deployments.DeploymentLog)
 }

--- a/resources/deployments/controller/rest_view.go
+++ b/resources/deployments/controller/rest_view.go
@@ -26,6 +26,7 @@ type RESTView interface {
 	RenderSuccessGet(w rest.ResponseWriter, object interface{})
 	RenderEmptySuccessResponse(w rest.ResponseWriter)
 	RenderError(w rest.ResponseWriter, err error, status int, l *log.Logger)
+	RenderInternalError(w rest.ResponseWriter, err error, l *log.Logger)
 	RenderErrorNotFound(w rest.ResponseWriter, l *log.Logger)
 	RenderDeploymentLog(w rest.ResponseWriter, dlog deployments.DeploymentLog)
 }

--- a/resources/images/controller/images.go
+++ b/resources/images/controller/images.go
@@ -71,7 +71,7 @@ func (s *SoftwareImagesController) GetImage(w rest.ResponseWriter, r *rest.Reque
 
 	image, err := s.model.GetImage(id)
 	if err != nil {
-		s.view.RenderError(w, err, http.StatusInternalServerError, l)
+		s.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -88,7 +88,7 @@ func (s *SoftwareImagesController) ListImages(w rest.ResponseWriter, r *rest.Req
 
 	list, err := s.model.ListImages(r.PathParams)
 	if err != nil {
-		s.view.RenderError(w, err, http.StatusInternalServerError, l)
+		s.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -113,7 +113,7 @@ func (s *SoftwareImagesController) DownloadLink(w rest.ResponseWriter, r *rest.R
 
 	link, err := s.model.DownloadLink(id, expire)
 	if err != nil {
-		s.view.RenderError(w, err, http.StatusInternalServerError, l)
+		s.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -179,7 +179,7 @@ func (s *SoftwareImagesController) DeleteImage(w rest.ResponseWriter, r *rest.Re
 			s.view.RenderErrorNotFound(w, l)
 			return
 		}
-		s.view.RenderError(w, err, http.StatusInternalServerError, l)
+		s.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -204,7 +204,7 @@ func (s *SoftwareImagesController) EditImage(w rest.ResponseWriter, r *rest.Requ
 
 	found, err := s.model.EditImage(id, constructor)
 	if err != nil {
-		s.view.RenderError(w, err, http.StatusInternalServerError, l)
+		s.view.RenderInternalError(w, err, l)
 		return
 	}
 
@@ -248,7 +248,11 @@ func (s *SoftwareImagesController) NewImage(w rest.ResponseWriter, r *rest.Reque
 
 	imageFile, metaYoctoConstructor, status, err := s.handleImage(imagePart, DefaultMaxImageSize)
 	if err != nil {
-		s.view.RenderError(w, err, status, l)
+		if status == http.StatusInternalServerError {
+			s.view.RenderInternalError(w, err, l)
+		} else {
+			s.view.RenderError(w, err, status, l)
+		}
 		return
 	}
 	defer os.Remove(imageFile.Name())
@@ -257,7 +261,7 @@ func (s *SoftwareImagesController) NewImage(w rest.ResponseWriter, r *rest.Reque
 	imgId, err := s.model.CreateImage(imageFile, metaConstructor, metaYoctoConstructor)
 	if err != nil {
 		// TODO: check if this is bad request or internal error
-		s.view.RenderError(w, err, http.StatusInternalServerError, l)
+		s.view.RenderInternalError(w, err, l)
 		return
 	}
 

--- a/resources/images/controller/images.go
+++ b/resources/images/controller/images.go
@@ -65,18 +65,18 @@ func (s *SoftwareImagesController) GetImage(w rest.ResponseWriter, r *rest.Reque
 	id := r.PathParam("id")
 
 	if !govalidator.IsUUIDv4(id) {
-		s.view.RenderError(w, ErrIDNotUUIDv4, http.StatusBadRequest, l)
+		s.view.RenderError(w, r, ErrIDNotUUIDv4, http.StatusBadRequest, l)
 		return
 	}
 
 	image, err := s.model.GetImage(id)
 	if err != nil {
-		s.view.RenderInternalError(w, err, l)
+		s.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
 	if image == nil {
-		s.view.RenderErrorNotFound(w, l)
+		s.view.RenderErrorNotFound(w, r, l)
 		return
 	}
 
@@ -88,7 +88,7 @@ func (s *SoftwareImagesController) ListImages(w rest.ResponseWriter, r *rest.Req
 
 	list, err := s.model.ListImages(r.PathParams)
 	if err != nil {
-		s.view.RenderInternalError(w, err, l)
+		s.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
@@ -101,24 +101,24 @@ func (s *SoftwareImagesController) DownloadLink(w rest.ResponseWriter, r *rest.R
 	id := r.PathParam("id")
 
 	if !govalidator.IsUUIDv4(id) {
-		s.view.RenderError(w, ErrIDNotUUIDv4, http.StatusBadRequest, l)
+		s.view.RenderError(w, r, ErrIDNotUUIDv4, http.StatusBadRequest, l)
 		return
 	}
 
 	expire, err := s.getLinkExpireParam(r, DefaultDownloadLinkExpire)
 	if err != nil {
-		s.view.RenderError(w, err, http.StatusBadRequest, l)
+		s.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
 	link, err := s.model.DownloadLink(id, expire)
 	if err != nil {
-		s.view.RenderInternalError(w, err, l)
+		s.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
 	if link == nil {
-		s.view.RenderErrorNotFound(w, l)
+		s.view.RenderErrorNotFound(w, r, l)
 		return
 	}
 
@@ -170,16 +170,16 @@ func (s *SoftwareImagesController) DeleteImage(w rest.ResponseWriter, r *rest.Re
 	id := r.PathParam("id")
 
 	if !govalidator.IsUUIDv4(id) {
-		s.view.RenderError(w, ErrIDNotUUIDv4, http.StatusBadRequest, l)
+		s.view.RenderError(w, r, ErrIDNotUUIDv4, http.StatusBadRequest, l)
 		return
 	}
 
 	if err := s.model.DeleteImage(id); err != nil {
 		if err == ErrImageMetaNotFound {
-			s.view.RenderErrorNotFound(w, l)
+			s.view.RenderErrorNotFound(w, r, l)
 			return
 		}
-		s.view.RenderInternalError(w, err, l)
+		s.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
@@ -192,24 +192,24 @@ func (s *SoftwareImagesController) EditImage(w rest.ResponseWriter, r *rest.Requ
 	id := r.PathParam("id")
 
 	if !govalidator.IsUUIDv4(id) {
-		s.view.RenderError(w, ErrIDNotUUIDv4, http.StatusBadRequest, l)
+		s.view.RenderError(w, r, ErrIDNotUUIDv4, http.StatusBadRequest, l)
 		return
 	}
 
 	constructor, err := s.getSoftwareImageMetaConstructorFromBody(r)
 	if err != nil {
-		s.view.RenderError(w, errors.Wrap(err, "Validating request body"), http.StatusBadRequest, l)
+		s.view.RenderError(w, r, errors.Wrap(err, "Validating request body"), http.StatusBadRequest, l)
 		return
 	}
 
 	found, err := s.model.EditImage(id, constructor)
 	if err != nil {
-		s.view.RenderInternalError(w, err, l)
+		s.view.RenderInternalError(w, r, err, l)
 		return
 	}
 
 	if !found {
-		s.view.RenderErrorNotFound(w, l)
+		s.view.RenderErrorNotFound(w, r, l)
 		return
 	}
 
@@ -234,7 +234,7 @@ func (s *SoftwareImagesController) NewImage(w rest.ResponseWriter, r *rest.Reque
 	// parse content type and params according to RFC 1521
 	_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil {
-		s.view.RenderError(w, err, http.StatusBadRequest, l)
+		s.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
@@ -242,16 +242,16 @@ func (s *SoftwareImagesController) NewImage(w rest.ResponseWriter, r *rest.Reque
 
 	metaConstructor, imagePart, err := s.handleMeta(mr, DefaultMaxMetaSize)
 	if err != nil || imagePart == nil {
-		s.view.RenderError(w, err, http.StatusBadRequest, l)
+		s.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
 	imageFile, metaYoctoConstructor, status, err := s.handleImage(imagePart, DefaultMaxImageSize)
 	if err != nil {
 		if status == http.StatusInternalServerError {
-			s.view.RenderInternalError(w, err, l)
+			s.view.RenderInternalError(w, r, err, l)
 		} else {
-			s.view.RenderError(w, err, status, l)
+			s.view.RenderError(w, r, err, status, l)
 		}
 		return
 	}
@@ -261,7 +261,7 @@ func (s *SoftwareImagesController) NewImage(w rest.ResponseWriter, r *rest.Reque
 	imgId, err := s.model.CreateImage(imageFile, metaConstructor, metaYoctoConstructor)
 	if err != nil {
 		// TODO: check if this is bad request or internal error
-		s.view.RenderInternalError(w, err, l)
+		s.view.RenderInternalError(w, r, err, l)
 		return
 	}
 

--- a/resources/images/controller/images_external_test.go
+++ b/resources/images/controller/images_external_test.go
@@ -410,7 +410,7 @@ func TestSoftwareImagesControllerNewImage(t *testing.T) {
 			InputModelError:  errors.New("create image error"),
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("create image error")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("internal error")),
 			},
 		},
 		{
@@ -578,7 +578,7 @@ func TestSoftwareImagesControllerDownloadLink(t *testing.T) {
 			InputModelError:  errors.New("file service down"),
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New(`file service down`)),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New(`internal error`)),
 			},
 		},
 		{
@@ -586,7 +586,7 @@ func TestSoftwareImagesControllerDownloadLink(t *testing.T) {
 			InputModelError: errors.New("file service down"),
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New(`file service down`)),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New(`internal error`)),
 			},
 		},
 		// no file found

--- a/resources/images/controller/images_external_test.go
+++ b/resources/images/controller/images_external_test.go
@@ -249,9 +249,11 @@ func TestControllerEditImage(t *testing.T) {
 
 	// correct id; correct payload; have image
 	imagesModel.editImage = true
-	recorded = test.RunRequest(t, api.MakeHandler(),
-		test.MakeSimpleRequest("PUT", "http://localhost/api/0.0.1/images/"+id,
-			map[string]string{"yocto_id": "1234-1234", "name": "myImage", "device_type": "myDevice"}))
+
+	req := test.MakeSimpleRequest("PUT", "http://localhost/api/0.0.1/images/"+id,
+		map[string]string{"yocto_id": "1234-1234", "name": "myImage", "device_type": "myDevice"})
+	req.Header.Add(requestid.RequestIdHeader, "test")
+	recorded = test.RunRequest(t, api.MakeHandler(), req)
 	recorded.CodeIs(http.StatusNoContent)
 	recorded.BodyIs("")
 }
@@ -448,8 +450,9 @@ func TestSoftwareImagesControllerNewImage(t *testing.T) {
 
 		api := setUpRestTest("/r", rest.Post, NewSoftwareImagesController(model, new(view.RESTView)).NewImage)
 
-		recorded := test.RunRequest(t, api.MakeHandler(),
-			MakeMultipartRequest("POST", "http://localhost/r", testCase.InputContentType, testCase.InputBodyObject))
+		req := MakeMultipartRequest("POST", "http://localhost/r", testCase.InputContentType, testCase.InputBodyObject)
+		req.Header.Add(requestid.RequestIdHeader, "test")
+		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
 	}
@@ -621,10 +624,11 @@ func TestSoftwareImagesControllerDownloadLink(t *testing.T) {
 			expire = "?expire=" + *testCase.InputParamExpire
 		}
 
-		recorded := test.RunRequest(t, api.MakeHandler(),
-			test.MakeSimpleRequest("POST",
-				fmt.Sprintf("http://localhost/%s%s", testCase.InputID, expire),
-				nil))
+		req := test.MakeSimpleRequest("POST",
+			fmt.Sprintf("http://localhost/%s%s", testCase.InputID, expire),
+			nil)
+		req.Header.Add(requestid.RequestIdHeader, "test")
+		recorded := test.RunRequest(t, api.MakeHandler(), req)
 
 		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
 	}

--- a/resources/images/controller/rest_view.go
+++ b/resources/images/controller/rest_view.go
@@ -22,9 +22,9 @@ import (
 type RESTView interface {
 	RenderSuccessPost(w rest.ResponseWriter, r *rest.Request, id string)
 	RenderSuccessGet(w rest.ResponseWriter, object interface{})
-	RenderError(w rest.ResponseWriter, err error, status int, l *log.Logger)
-	RenderInternalError(w rest.ResponseWriter, err error, l *log.Logger)
-	RenderErrorNotFound(w rest.ResponseWriter, l *log.Logger)
+	RenderError(w rest.ResponseWriter, r *rest.Request, err error, status int, l *log.Logger)
+	RenderInternalError(w rest.ResponseWriter, r *rest.Request, err error, l *log.Logger)
+	RenderErrorNotFound(w rest.ResponseWriter, r *rest.Request, l *log.Logger)
 	RenderSuccessDelete(w rest.ResponseWriter)
 	RenderSuccessPut(w rest.ResponseWriter)
 }

--- a/resources/images/controller/rest_view.go
+++ b/resources/images/controller/rest_view.go
@@ -23,6 +23,7 @@ type RESTView interface {
 	RenderSuccessPost(w rest.ResponseWriter, r *rest.Request, id string)
 	RenderSuccessGet(w rest.ResponseWriter, object interface{})
 	RenderError(w rest.ResponseWriter, err error, status int, l *log.Logger)
+	RenderInternalError(w rest.ResponseWriter, err error, l *log.Logger)
 	RenderErrorNotFound(w rest.ResponseWriter, l *log.Logger)
 	RenderSuccessDelete(w rest.ResponseWriter)
 	RenderSuccessPut(w rest.ResponseWriter)

--- a/resources/images/view/view.go
+++ b/resources/images/view/view.go
@@ -50,6 +50,11 @@ func (p *RESTView) RenderError(w rest.ResponseWriter, err error, status int, l *
 	rest.Error(w, err.Error(), status)
 }
 
+func (p *RESTView) RenderInternalError(w rest.ResponseWriter, err error, l *log.Logger) {
+	l.F(log.Ctx{log.LogHttpCode: http.StatusInternalServerError}).Error(err.Error())
+	rest.Error(w, "internal error", http.StatusInternalServerError)
+}
+
 func (p *RESTView) RenderErrorNotFound(w rest.ResponseWriter, l *log.Logger) {
 	p.RenderError(w, ErrNotFound, http.StatusNotFound, l)
 }

--- a/resources/images/view/view_external_test.go
+++ b/resources/images/view/view_external_test.go
@@ -110,7 +110,7 @@ func TestRenderErrorNotFound(t *testing.T) {
 	router, err := rest.MakeRouter(rest.Get("/test", func(w rest.ResponseWriter, r *rest.Request) {
 
 		l := log.New(log.Ctx{})
-		new(RESTView).RenderErrorNotFound(w, l)
+		new(RESTView).RenderErrorNotFound(w, r, l)
 	}))
 
 	if err != nil {
@@ -124,5 +124,5 @@ func TestRenderErrorNotFound(t *testing.T) {
 		test.MakeSimpleRequest("GET", "http://localhost/test", nil))
 
 	recorded.CodeIs(http.StatusNotFound)
-	recorded.BodyIs(`{"Error":"Resource not found"}`)
+	recorded.BodyIs(`{"error":"Resource not found","request_id":""}`)
 }

--- a/utils/testing/conversion.go
+++ b/utils/testing/conversion.go
@@ -15,5 +15,11 @@
 package testing
 
 func ErrorToErrStruct(err error) interface{} {
-	return struct{ Error string }{err.Error()}
+	return struct{
+		Error string `json:"error"`
+		RequestId string `json:"request_id"`
+	} {
+		err.Error(),
+		"test",
+	}
 }

--- a/utils/testing/conversion_external_test.go
+++ b/utils/testing/conversion_external_test.go
@@ -24,5 +24,11 @@ import (
 
 func TestErrorToErrStruct(t *testing.T) {
 	errStr := "ala ma kota"
-	assert.Equal(t, struct{ Error string }{errStr}, ErrorToErrStruct(errors.New(errStr)))
+	assert.Equal(t, struct{
+		Error string `json:"error"`
+		RequestId string `json:"request_id"`
+	} {
+		errStr,
+		"test",
+	}, ErrorToErrStruct(errors.New(errStr)))
 }


### PR DESCRIPTION
Issues: MEN-501

Basicaly, all 500 responses were changed to they return `{"error": "internal error", "request_id": "..."}` and log error from lower levels. 4xx errors return mostly general errors, in case of validation - more detailed.

Additionaly all errors include request id in response body.

@maciejmrowiec  @mchalski 