### PR TITLE
Assign MIME type for artifact

### DIFF
--- a/resources/deployments/model/deployments.go
+++ b/resources/deployments/model/deployments.go
@@ -34,21 +34,26 @@ type DeploymentsModel struct {
 	deviceDeploymentLogsStorage DeviceDeploymentLogsStorage
 	imageLinker                 GetRequester
 	deviceDeploymentGenerator   Generator
+	imageContentType            string
 }
 
-func NewDeploymentModel(
-	deploymentsStorage DeploymentsStorage,
-	deviceDeploymentGenerator Generator,
-	deviceDeploymentsStorage DeviceDeploymentStorage,
-	deviceDeploymentLogsStorage DeviceDeploymentLogsStorage,
-	imageLinker GetRequester,
-) *DeploymentsModel {
+type DeploymentsModelConfig struct {
+	DeploymentsStorage          DeploymentsStorage
+	DeviceDeploymentsStorage    DeviceDeploymentStorage
+	DeviceDeploymentLogsStorage DeviceDeploymentLogsStorage
+	ImageLinker                 GetRequester
+	DeviceDeploymentGenerator   Generator
+	ImageContentType            string
+}
+
+func NewDeploymentModel(config DeploymentsModelConfig) *DeploymentsModel {
 	return &DeploymentsModel{
-		deploymentsStorage:          deploymentsStorage,
-		deviceDeploymentsStorage:    deviceDeploymentsStorage,
-		deviceDeploymentLogsStorage: deviceDeploymentLogsStorage,
-		imageLinker:                 imageLinker,
-		deviceDeploymentGenerator:   deviceDeploymentGenerator,
+		deploymentsStorage:          config.DeploymentsStorage,
+		deviceDeploymentsStorage:    config.DeviceDeploymentsStorage,
+		deviceDeploymentLogsStorage: config.DeviceDeploymentLogsStorage,
+		imageLinker:                 config.ImageLinker,
+		deviceDeploymentGenerator:   config.DeviceDeploymentGenerator,
+		imageContentType:            config.ImageContentType,
 	}
 }
 
@@ -154,7 +159,7 @@ func (d *DeploymentsModel) GetDeploymentForDevice(deviceID string) (*deployments
 		return nil, nil
 	}
 
-	link, err := d.imageLinker.GetRequest(*deployment.Image.Id, DefaultUpdateDownloadLinkExpire)
+	link, err := d.imageLinker.GetRequest(*deployment.Image.Id, DefaultUpdateDownloadLinkExpire, d.imageContentType)
 	if err != nil {
 		return nil, errors.Wrap(err, "Generating download link for the device")
 	}

--- a/resources/deployments/model/deployments_external_test.go
+++ b/resources/deployments/model/deployments_external_test.go
@@ -65,7 +65,7 @@ func TestDeploymentModelGetDeployment(t *testing.T) {
 		deploymentStorage.On("FindByID", testCase.InputDeploymentID).
 			Return(testCase.InoutFindByIDDeployment, testCase.InoutFindByIDError)
 
-		model := NewDeploymentModel(deploymentStorage, nil, nil, nil, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{DeploymentsStorage: deploymentStorage})
 
 		deployment, err := model.GetDeployment(testCase.InputDeploymentID)
 		if testCase.OutputError != nil {
@@ -118,7 +118,7 @@ func TestDeploymentModelImageUsedInActiveDeployment(t *testing.T) {
 			Return(testCase.InputExistAssignedImageWithIDAndStatusesFound,
 				testCase.InputExistAssignedImageWithIDAndStatusesError)
 
-		model := NewDeploymentModel(nil, nil, deviceDeploymentStorage, nil, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{DeviceDeploymentsStorage: deviceDeploymentStorage})
 
 		found, err := model.ImageUsedInActiveDeployment(testCase.InputID)
 		if testCase.OutputError != nil {
@@ -172,7 +172,7 @@ func TestDeploymentModelImageUsedInDeployment(t *testing.T) {
 			Return(testCase.InputImageUsedInDeploymentFound,
 				testCase.InputImageUsedInDeploymentError)
 
-		model := NewDeploymentModel(nil, nil, deviceDeploymentStorage, nil, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{DeviceDeploymentsStorage: deviceDeploymentStorage})
 
 		found, err := model.ImageUsedInDeployment(testCase.InputID)
 		if testCase.OutputError != nil {
@@ -257,7 +257,10 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 		imageLinker.On("GetRequest", "ID:456", DefaultUpdateDownloadLinkExpire).
 			Return(testCase.InputGetRequestLink, testCase.InputGetRequestError)
 
-		model := NewDeploymentModel(nil, nil, deviceDeploymentStorage, nil, imageLinker)
+		model := NewDeploymentModel(DeploymentsModelConfig{
+			DeviceDeploymentsStorage: deviceDeploymentStorage,
+			ImageLinker:              imageLinker,
+		})
 
 		out, err := model.GetDeploymentForDevice(testCase.InputID)
 		if testCase.OutputError != nil {
@@ -378,7 +381,11 @@ func TestDeploymentModelCreateDeployment(t *testing.T) {
 		deviceDeploymentStorage.On("InsertMany", mock.AnythingOfType("[]*deployments.DeviceDeployment")).
 			Return(testCase.InputDeviceDeploymentStorageInsertManyError)
 
-		model := NewDeploymentModel(deploymentStorage, generator, deviceDeploymentStorage, nil, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{
+			DeploymentsStorage:        deploymentStorage,
+			DeviceDeploymentGenerator: generator,
+			DeviceDeploymentsStorage:  deviceDeploymentStorage,
+		})
 
 		out, err := model.CreateDeployment(context.Background(), testCase.InputConstructor)
 		if testCase.OutputError != nil {
@@ -508,7 +515,10 @@ func TestDeploymentModelUpdateDeviceDeploymentStatus(t *testing.T) {
 			*testCase.InputDeployment.Id, mock.AnythingOfType("time.Time")).
 			Return(testCase.InputDepsFinishError)
 
-		model := NewDeploymentModel(deploymentStorage, nil, deviceDeploymentStorage, nil, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{
+			DeploymentsStorage:       deploymentStorage,
+			DeviceDeploymentsStorage: deviceDeploymentStorage,
+		})
 
 		err := model.UpdateDeviceDeploymentStatus(*testCase.InputDeployment.Id,
 			testCase.InputDeviceID, testCase.InputStatus)
@@ -622,7 +632,10 @@ func TestGetDeploymentStats(t *testing.T) {
 		deploymentStorage.On("FindByID", testCase.InputDeploymentID).
 			Return(testCase.InoutFindByIDDeployment, testCase.InoutFindByIDError)
 
-		model := NewDeploymentModel(deploymentStorage, nil, deviceDeploymentStorage, nil, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{
+			DeploymentsStorage:       deploymentStorage,
+			DeviceDeploymentsStorage: deviceDeploymentStorage,
+		})
 
 		stats, err := model.GetDeploymentStats(testCase.InputDeploymentID)
 
@@ -715,7 +728,10 @@ func TestDeploymentModelGetDeviceStatusesForDeployment(t *testing.T) {
 		depsDb.On("FindByID", tc.inDeploymentId).
 			Return(tc.depsStorageDeployment, tc.depsStorageErr)
 
-		model := NewDeploymentModel(depsDb, nil, devsDb, nil, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{
+			DeploymentsStorage:       depsDb,
+			DeviceDeploymentsStorage: devsDb,
+		})
 		statuses, err := model.GetDeviceStatusesForDeployment(tc.inDeploymentId)
 
 		if tc.modelErr != nil {
@@ -808,8 +824,10 @@ func TestDeploymentModelSaveDeviceDeploymentLog(t *testing.T) {
 			testCase.InputDeviceID).
 			Return(testCase.InputHasDeployment, testCase.InputHasModelError)
 
-		model := NewDeploymentModel(nil, nil, deviceDeploymentStorage,
-			deviceDeploymentLogStorage, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{
+			DeviceDeploymentsStorage:    deviceDeploymentStorage,
+			DeviceDeploymentLogsStorage: deviceDeploymentLogStorage,
+		})
 
 		err := model.SaveDeviceDeploymentLog(testCase.InputDeviceID,
 			testCase.InputDeploymentID, testCase.InputLog)
@@ -854,7 +872,7 @@ func TestDeploymentModelLookupDeployment(t *testing.T) {
 		deploymentStorage.On("Find", mock.AnythingOfType("deployments.Query")).
 			Return(testCase.MockDeployments, testCase.MockError)
 
-		model := NewDeploymentModel(deploymentStorage, nil, nil, nil, nil)
+		model := NewDeploymentModel(DeploymentsModelConfig{DeploymentsStorage: deploymentStorage})
 
 		deployments, err := model.LookupDeployment(deployments.Query{})
 		if testCase.OutputError != nil {

--- a/resources/deployments/model/get_requester.go
+++ b/resources/deployments/model/get_requester.go
@@ -22,5 +22,5 @@ import (
 
 // Responsible for providing GET method requests to requested artifact
 type GetRequester interface {
-	GetRequest(objectId string, duration time.Duration) (*images.Link, error)
+	GetRequest(objectId string, duration time.Duration, responseContentType string) (*images.Link, error)
 }

--- a/resources/deployments/model/mocks/GetRequester.go
+++ b/resources/deployments/model/mocks/GetRequester.go
@@ -27,12 +27,12 @@ type GetRequester struct {
 }
 
 // GetRequest provides a mock function with given fields: objectId, duration
-func (_m *GetRequester) GetRequest(objectId string, duration time.Duration) (*images.Link, error) {
+func (_m *GetRequester) GetRequest(objectId string, duration time.Duration, responseContentType string) (*images.Link, error) {
 	ret := _m.Called(objectId, duration)
 
 	var r0 *images.Link
-	if rf, ok := ret.Get(0).(func(string, time.Duration) *images.Link); ok {
-		r0 = rf(objectId, duration)
+	if rf, ok := ret.Get(0).(func(string, time.Duration, string) *images.Link); ok {
+		r0 = rf(objectId, duration, responseContentType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*images.Link)
@@ -40,8 +40,8 @@ func (_m *GetRequester) GetRequest(objectId string, duration time.Duration) (*im
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, time.Duration) error); ok {
-		r1 = rf(objectId, duration)
+	if rf, ok := ret.Get(1).(func(string, time.Duration, string) error); ok {
+		r1 = rf(objectId, duration, responseContentType)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/resources/images/model/file_storage.go
+++ b/resources/images/model/file_storage.go
@@ -33,6 +33,6 @@ type FileStorage interface {
 	Exists(objectId string) (bool, error)
 	LastModified(objectId string) (time.Time, error)
 	PutRequest(objectId string, duration time.Duration) (*images.Link, error)
-	GetRequest(objectId string, duration time.Duration) (*images.Link, error)
-	PutFile(objectId string, image *os.File) error
+	GetRequest(objectId string, duration time.Duration, responseContentType string) (*images.Link, error)
+	PutFile(objectId string, image *os.File, contentType string) error
 }

--- a/resources/images/model/images.go
+++ b/resources/images/model/images.go
@@ -30,6 +30,10 @@ var (
 	ErrModelImageUsedInAnyDeployment = errors.New("Image have been already used in deployment")
 )
 
+const (
+	ImageContentType = "application/vnd.mender-artifact"
+)
+
 type ImagesModel struct {
 	fileStorage   FileStorage
 	deployments   ImageUsedIn
@@ -70,7 +74,7 @@ func (i *ImagesModel) CreateImage(
 		return "", errors.Wrap(err, "Fail to store the metadata")
 	}
 
-	if err := i.fileStorage.PutFile(*image.Id, imageFile); err != nil {
+	if err := i.fileStorage.PutFile(*image.Id, imageFile, ImageContentType); err != nil {
 		i.imagesStorage.Delete(*image.Id)
 		return "", errors.Wrap(err, "Fail to store the image")
 	}
@@ -206,7 +210,7 @@ func (i *ImagesModel) DownloadLink(imageID string, expire time.Duration) (*image
 		return nil, nil
 	}
 
-	link, err := i.fileStorage.GetRequest(imageID, expire)
+	link, err := i.fileStorage.GetRequest(imageID, expire, ImageContentType)
 	if err != nil {
 		return nil, errors.Wrap(err, "Generating download link")
 	}

--- a/resources/images/model/images_test.go
+++ b/resources/images/model/images_test.go
@@ -206,11 +206,11 @@ func (ffs *FakeFileStorage) PutRequest(objectId string, duration time.Duration) 
 	return ffs.putReq, ffs.putError
 }
 
-func (ffs *FakeFileStorage) GetRequest(objectId string, duration time.Duration) (*images.Link, error) {
+func (ffs *FakeFileStorage) GetRequest(objectId string, duration time.Duration, responseContentType string) (*images.Link, error) {
 	return ffs.getReq, ffs.getError
 }
 
-func (fis *FakeFileStorage) PutFile(id string, img *os.File) error {
+func (fis *FakeFileStorage) PutFile(id string, img *os.File, contentType string) error {
 	return fis.putFileError
 }
 

--- a/resources/images/s3/filestorage.go
+++ b/resources/images/s3/filestorage.go
@@ -163,12 +163,16 @@ func (s *SimpleStorageService) Exists(objectID string) (bool, error) {
 }
 
 // Puts object into AWS S3
-func (s *SimpleStorageService) PutFile(objectID string, image *os.File) error {
+func (s *SimpleStorageService) PutFile(objectID string, image *os.File, contentType string) error {
 
 	params := &s3.PutObjectInput{
 		Body:   image,
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(objectID),
+	}
+
+	if contentType != "" {
+		params.ContentType = &contentType
 	}
 
 	// Ignore out object?
@@ -201,7 +205,7 @@ func (s *SimpleStorageService) PutRequest(objectID string, duration time.Duratio
 }
 
 // GetRequest duration is limited to 7 days (AWS limitation)
-func (s *SimpleStorageService) GetRequest(objectID string, duration time.Duration) (*images.Link, error) {
+func (s *SimpleStorageService) GetRequest(objectID string, duration time.Duration, responseContentType string) (*images.Link, error) {
 
 	if err := s.validateDurationLimits(duration); err != nil {
 		return nil, err
@@ -210,6 +214,10 @@ func (s *SimpleStorageService) GetRequest(objectID string, duration time.Duratio
 	params := &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(objectID),
+	}
+
+	if responseContentType != "" {
+		params.ResponseContentType = &responseContentType
 	}
 
 	// Ignore out object

--- a/routing.go
+++ b/routing.go
@@ -78,17 +78,18 @@ func NewRouter(c config.ConfigReader) (rest.App, error) {
 		return nil, errors.Wrap(err, "init inventory client")
 	}
 
-	// Domian Models
-	deploymentModel := deploymentsModel.NewDeploymentModel(
-		deploymentsStorage,
-		generator.NewImageBasedDeviceDeployment(
+	// Domain Models
+	deploymentModel := deploymentsModel.NewDeploymentModel(deploymentsModel.DeploymentsModelConfig{
+		DeploymentsStorage:          deploymentsStorage,
+		DeviceDeploymentsStorage:    deviceDeploymentsStorage,
+		DeviceDeploymentLogsStorage: deviceDeploymentLogsStorage,
+		ImageLinker:                 fileStorage,
+		DeviceDeploymentGenerator: generator.NewImageBasedDeviceDeployment(
 			imagesStorage,
 			generator.NewInventory(inventory),
 		),
-		deviceDeploymentsStorage,
-		deviceDeploymentLogsStorage,
-		fileStorage,
-	)
+		ImageContentType: imagesModel.ImageContentType,
+	})
 
 	imagesModel := imagesModel.NewImagesModel(fileStorage, deploymentModel, imagesStorage)
 


### PR DESCRIPTION
Issues: MEN-676

Theoretically it should be enough to set `Content-Type` in `PutObjectInfo`. For Amazon S3 it is, but for minio - it is not. I tried to trace down this bug, but it's very hard to do so, because I can't even verify if metadata are stored correctly. There is a workaround for that - setting response content-type when generating download link and it is exactly what I did.

@kjaskiewiczz  @bboozzoo 
