### PR TITLE
artifact id in request

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -27,7 +27,7 @@ responses:
       $ref: "#/definitions/Error"
 
 paths:
-  /device/update:
+  /device/deployments/next:
     get:
       summary: Get a next update
       description: |
@@ -39,6 +39,16 @@ paths:
           type: string
           format: Bearer [token]
           description: Contains the JWT token issued by the Device Authentication Service.
+        - name: artifact
+          in: query
+          required: false
+          type: string
+          description: ID of currently installed artifact
+        - name: device_type
+          in: query
+          required: false
+          type: string
+          description: Device type of device
       produces:
         - application/json
       responses:

--- a/resources/deployments/deployment_instructions.go
+++ b/resources/deployments/deployment_instructions.go
@@ -17,21 +17,21 @@ package deployments
 import "github.com/mendersoftware/deployments/resources/images"
 
 type ImageInstallInstructions struct {
-	*images.Link
-	*images.SoftwareImage
+	images.Link
+	images.SoftwareImage
 }
 
 type DeploymentInstructions struct {
-	ID    *string                  `json:"id"`
+	ID    string                   `json:"id"`
 	Image ImageInstallInstructions `json:"image"`
 }
 
 func NewDeploymentInstructions(id string, link *images.Link, image *images.SoftwareImage) *DeploymentInstructions {
 	return &DeploymentInstructions{
-		ID: &id,
+		ID: id,
 		Image: ImageInstallInstructions{
-			Link:          link,
-			SoftwareImage: image,
+			Link:          *link,
+			SoftwareImage: *image,
 		},
 	}
 }

--- a/resources/deployments/model/deployments.go
+++ b/resources/deployments/model/deployments.go
@@ -173,7 +173,7 @@ func (d *DeploymentsModel) GetDeploymentForDevice(deviceID string) (*deployments
 		return nil, nil
 	}
 
-	link, err := d.imageLinker.GetRequest(*deployment.Image.Id, DefaultUpdateDownloadLinkExpire, d.imageContentType)
+	link, err := d.imageLinker.GetRequest(deployment.Image.Id, DefaultUpdateDownloadLinkExpire, d.imageContentType)
 	if err != nil {
 		return nil, errors.Wrap(err, "Generating download link for the device")
 	}

--- a/resources/deployments/model/deployments_external_test.go
+++ b/resources/deployments/model/deployments_external_test.go
@@ -189,6 +189,14 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 
 	t.Parallel()
 
+	image := images.NewSoftwareImage(
+		&images.SoftwareImageMetaConstructor{
+			Name: "foo",
+		},
+		&images.SoftwareImageMetaYoctoConstructor{
+			YoctoId: "foo-artifact",
+		})
+
 	testCases := []struct {
 		InputID string
 
@@ -216,9 +224,13 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 		{
 			InputID: "ID:123",
 			InputOlderstDeviceDeployment: &deployments.DeviceDeployment{
-				Image: &images.SoftwareImage{
-					Id: "ID:456",
-				},
+				Image: images.NewSoftwareImage(
+					&images.SoftwareImageMetaConstructor{
+						Name: "foo",
+					},
+					&images.SoftwareImageMetaYoctoConstructor{
+						YoctoId: "foo-artifact",
+					}),
 			},
 			InputGetRequestError: errors.New("file storage error"),
 
@@ -227,9 +239,7 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 		{
 			InputID: "ID:123",
 			InputOlderstDeviceDeployment: &deployments.DeviceDeployment{
-				Image: &images.SoftwareImage{
-					Id: "ID:456",
-				},
+				Image:        image,
 				DeploymentId: StringToPointer("ID:678"),
 			},
 			InputGetRequestLink: &images.Link{},
@@ -237,14 +247,12 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 			OutputDeploymentInstructions: deployments.NewDeploymentInstructions(
 				"ID:678",
 				&images.Link{},
-				&images.SoftwareImage{
-					Id: "ID:456",
-				},
-			),
+				image),
 		},
 	}
 
-	for _, testCase := range testCases {
+	for tidx, testCase := range testCases {
+		t.Logf("test case %d", tidx)
 
 		deviceDeploymentStorage := new(mocks.DeviceDeploymentStorage)
 		deviceDeploymentStorage.On("FindOldestDeploymentForDeviceIDWithStatuses", testCase.InputID, mock.AnythingOfType("[]string")).
@@ -252,10 +260,15 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 				testCase.InputOlderstDeviceDeploymentError)
 
 		imageLinker := new(mocks.GetRequester)
-		// Notice: force GetRequest to expect image id returned by FindOldestDeploymentForDeviceIDWithStatuses
-		//         Just as implementation does, if this changes test will break by panic ;)
-		imageLinker.On("GetRequest", "ID:456", DefaultUpdateDownloadLinkExpire).
-			Return(testCase.InputGetRequestLink, testCase.InputGetRequestError)
+		if testCase.InputOlderstDeviceDeployment != nil {
+			// Notice: force GetRequest to expect image id returned
+			// by FindOldestDeploymentForDeviceIDWithStatuses Just
+			// as implementation does, if this changes test will
+			// break by panic ;)
+			imageLinker.On("GetRequest", testCase.InputOlderstDeviceDeployment.Image.Id,
+				DefaultUpdateDownloadLinkExpire).
+				Return(testCase.InputGetRequestLink, testCase.InputGetRequestError)
+		}
 
 		model := NewDeploymentModel(DeploymentsModelConfig{
 			DeviceDeploymentsStorage: deviceDeploymentStorage,
@@ -265,10 +278,20 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 		out, err := model.GetDeploymentForDevice(testCase.InputID)
 		if testCase.OutputError != nil {
 			assert.EqualError(t, err, testCase.OutputError.Error())
+			assert.Nil(t, out)
 		} else {
 			assert.NoError(t, err)
+			if testCase.OutputDeploymentInstructions != nil {
+				assert.NotNil(t, out)
+				assert.WithinDuration(t, time.Now(),
+					*out.Image.Modified, time.Second)
+				// zero out Modified field, so that the test below works
+				out.Image.Modified = testCase.OutputDeploymentInstructions.Image.Modified
+				assert.EqualValues(t, testCase.OutputDeploymentInstructions, out)
+			} else {
+				assert.Nil(t, out)
+			}
 		}
-		assert.Equal(t, testCase.OutputDeploymentInstructions, out)
 	}
 
 }

--- a/resources/deployments/model/deployments_external_test.go
+++ b/resources/deployments/model/deployments_external_test.go
@@ -217,7 +217,7 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 			InputID: "ID:123",
 			InputOlderstDeviceDeployment: &deployments.DeviceDeployment{
 				Image: &images.SoftwareImage{
-					Id: StringToPointer("ID:456"),
+					Id: "ID:456",
 				},
 			},
 			InputGetRequestError: errors.New("file storage error"),
@@ -228,7 +228,7 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 			InputID: "ID:123",
 			InputOlderstDeviceDeployment: &deployments.DeviceDeployment{
 				Image: &images.SoftwareImage{
-					Id: StringToPointer("ID:456"),
+					Id: "ID:456",
 				},
 				DeploymentId: StringToPointer("ID:678"),
 			},
@@ -238,7 +238,7 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 				"ID:678",
 				&images.Link{},
 				&images.SoftwareImage{
-					Id: StringToPointer("ID:456"),
+					Id: "ID:456",
 				},
 			),
 		},

--- a/resources/images/controller/images.go
+++ b/resources/images/controller/images.go
@@ -280,15 +280,17 @@ func (s *SoftwareImagesController) handleMeta(mr *multipart.Reader, maxMetaSize 
 		}
 		switch p.FormName() {
 		case "name":
-			constructor.Name, err = s.getFormFieldValue(p, maxMetaSize)
+			name, err := s.getFormFieldValue(p, maxMetaSize)
 			if err != nil {
 				return nil, nil, err
 			}
+			constructor.Name = *name
 		case "description":
-			constructor.Description, err = s.getFormFieldValue(p, maxMetaSize)
+			desc, err := s.getFormFieldValue(p, maxMetaSize)
 			if err != nil {
 				return nil, nil, err
 			}
+			constructor.Description = *desc
 		case "firmware":
 			if err := constructor.Validate(); err != nil {
 				return nil, nil, errors.Wrap(err, "Validating metadata")
@@ -370,10 +372,10 @@ func (s *SoftwareImagesController) getMetaFromArchive(
 	}
 	for _, p := range w {
 		deviceType := p.GetDeviceType()
-		metaYocto.DeviceType = &deviceType
+		metaYocto.DeviceType = deviceType
 		if rp, ok := p.(*parser.RootfsParser); ok {
 			yoctoId := rp.GetImageID()
-			metaYocto.YoctoId = &yoctoId
+			metaYocto.YoctoId = yoctoId
 		}
 		updateFiles := p.GetUpdateFiles()
 		if len(updateFiles) != 1 {
@@ -384,9 +386,9 @@ func (s *SoftwareImagesController) getMetaFromArchive(
 				return nil, errors.New("Image too large")
 			}
 			checksum := string(u.Checksum)
-			metaYocto.Checksum = &checksum
+			metaYocto.Checksum = checksum
 			metaYocto.ImageSize = u.Size / (1024 * 1024)
-			metaYocto.DateBuild = u.Date
+			metaYocto.DateBuild = &u.Date
 		}
 	}
 	return metaYocto, nil

--- a/resources/images/image.go
+++ b/resources/images/image.go
@@ -24,10 +24,10 @@ import (
 // Informations provided by the user
 type SoftwareImageMetaConstructor struct {
 	// Application Name & Version
-	Name *string `json:"name" bson:"name" valid:"length(1|4096),required"`
+	Name string `json:"name" bson:"name" valid:"length(1|4096),required"`
 
 	// Image description
-	Description *string `json:"description,omitempty" valid:"length(1|4096),optional"`
+	Description string `json:"description,omitempty" valid:"length(1|4096),optional"`
 }
 
 // Creates new, empty SoftwareImageMetaConstructor
@@ -44,19 +44,19 @@ func (s *SoftwareImageMetaConstructor) Validate() error {
 // Information provided with YOCTO image
 type SoftwareImageMetaYoctoConstructor struct {
 	// Yocto ID build in the image
-	YoctoId *string `json:"yocto_id" valid:"length(1|4096),required"`
+	YoctoId string `json:"yocto_id" valid:"length(1|4096),required"`
 
 	// Compatible device model for the application
-	DeviceType *string `json:"device_type" bson:"device_type" valid:"length(1|4096),required"`
+	DeviceType string `json:"device_type" bson:"device_type" valid:"length(1|4096),required"`
 
 	// Image file checksum
-	Checksum *string `json:"checksum" valid:"required"`
+	Checksum string `json:"checksum" valid:"required"`
 
 	// Image size
 	ImageSize int64 `json:"image_size" valid:"optional"`
 
 	// Date build
-	DateBuild time.Time `json:"date_build" valid:"optional"`
+	DateBuild *time.Time `json:"date_build" valid:"optional"`
 }
 
 func NewSoftwareImageMetaYoctoConstructor() *SoftwareImageMetaYoctoConstructor {
@@ -72,13 +72,13 @@ func (s *SoftwareImageMetaYoctoConstructor) Validate() error {
 // SoftwareImage YOCTO image with user application
 type SoftwareImage struct {
 	// User provided field set
-	*SoftwareImageMetaConstructor `bson:"meta"`
+	SoftwareImageMetaConstructor `bson:"meta"`
 
 	// Field set provided with yocto image
-	*SoftwareImageMetaYoctoConstructor `bson:"meta_yocto"`
+	SoftwareImageMetaYoctoConstructor `bson:"meta_yocto"`
 
 	// Image ID
-	Id *string `json:"id" bson:"_id" valid:"uuidv4,required"`
+	Id string `json:"id" bson:"_id" valid:"uuidv4,required"`
 
 	// Status if image was verified after upload
 	Verified bool `json:"verified" valid:"-"`
@@ -96,11 +96,11 @@ func NewSoftwareImage(
 	id := uuid.NewV4().String()
 
 	return &SoftwareImage{
-		SoftwareImageMetaConstructor:      metaConstructor,
-		SoftwareImageMetaYoctoConstructor: metaYoctoConstructor,
+		SoftwareImageMetaConstructor:      *metaConstructor,
+		SoftwareImageMetaYoctoConstructor: *metaYoctoConstructor,
 		Modified: &now,
 		Verified: false,
-		Id:       &id,
+		Id:       id,
 	}
 }
 

--- a/resources/images/image_test.go
+++ b/resources/images/image_test.go
@@ -36,7 +36,7 @@ func TestValidateCorrectImageMeta(t *testing.T) {
 	image := NewSoftwareImageMetaConstructor()
 	required := "required"
 
-	image.Name = &required
+	image.Name = required
 
 	if err := image.Validate(); err != nil {
 		t.FailNow()
@@ -47,9 +47,9 @@ func TestValidateCorrectImageMetaYocot(t *testing.T) {
 	image := NewSoftwareImageMetaYoctoConstructor()
 	required := "required"
 
-	image.YoctoId = &required
-	image.DeviceType = &required
-	image.Checksum = &required
+	image.YoctoId = required
+	image.DeviceType = required
+	image.Checksum = required
 
 	if err := image.Validate(); err != nil {
 		t.FailNow()
@@ -61,10 +61,10 @@ func TestValidateCorrectImage(t *testing.T) {
 	imageMeta := NewSoftwareImageMetaConstructor()
 	imageMetaYocto := NewSoftwareImageMetaYoctoConstructor()
 
-	imageMetaYocto.YoctoId = &required
-	imageMetaYocto.DeviceType = &required
-	imageMetaYocto.Checksum = &required
-	imageMeta.Name = &required
+	imageMetaYocto.YoctoId = required
+	imageMetaYocto.DeviceType = required
+	imageMetaYocto.Checksum = required
+	imageMeta.Name = required
 
 	image := NewSoftwareImage(imageMeta, imageMetaYocto)
 

--- a/resources/images/model/images.go
+++ b/resources/images/model/images.go
@@ -74,12 +74,12 @@ func (i *ImagesModel) CreateImage(
 		return "", errors.Wrap(err, "Fail to store the metadata")
 	}
 
-	if err := i.fileStorage.PutFile(*image.Id, imageFile, ImageContentType); err != nil {
-		i.imagesStorage.Delete(*image.Id)
+	if err := i.fileStorage.PutFile(image.Id, imageFile, ImageContentType); err != nil {
+		i.imagesStorage.Delete(image.Id)
 		return "", errors.Wrap(err, "Fail to store the image")
 	}
 
-	return *image.Id, nil
+	return image.Id, nil
 }
 
 // GetImage allows to fetch image obeject with specified id

--- a/resources/images/model/images_test.go
+++ b/resources/images/model/images_test.go
@@ -84,7 +84,7 @@ func createValidImageMeta() *images.SoftwareImageMetaConstructor {
 	imageMeta := images.NewSoftwareImageMetaConstructor()
 	required := "required"
 
-	imageMeta.Name = &required
+	imageMeta.Name = required
 
 	return imageMeta
 }
@@ -93,9 +93,9 @@ func createValidImageMetaYocto() *images.SoftwareImageMetaYoctoConstructor {
 	imageMetaYocto := images.NewSoftwareImageMetaYoctoConstructor()
 	required := "required"
 
-	imageMetaYocto.DeviceType = &required
-	imageMetaYocto.YoctoId = &required
-	imageMetaYocto.Checksum = &required
+	imageMetaYocto.DeviceType = required
+	imageMetaYocto.YoctoId = required
+	imageMetaYocto.Checksum = required
 
 	return imageMetaYocto
 }

--- a/resources/images/mongo/images.go
+++ b/resources/images/mongo/images.go
@@ -110,7 +110,7 @@ func (i *SoftwareImagesStorage) Update(image *images.SoftwareImage) (bool, error
 	defer session.Close()
 
 	image.SetModified(time.Now())
-	if err := session.DB(DatabaseName).C(CollectionImages).UpdateId(*image.Id, image); err != nil {
+	if err := session.DB(DatabaseName).C(CollectionImages).UpdateId(image.Id, image); err != nil {
 		if err.Error() == mgo.ErrNotFound.Error() {
 			return false, nil
 		}

--- a/routing.go
+++ b/routing.go
@@ -140,7 +140,7 @@ func NewDeploymentsResourceRoutes(controller *deploymentsController.DeploymentsC
 		rest.Put("/api/0.0.1/deployments/:id/status", controller.AbortDeployment),
 
 		// Devices
-		rest.Get("/api/0.0.1/device/update", controller.GetDeploymentForDevice),
+		rest.Get("/api/0.0.1/device/deployments/next", controller.GetDeploymentForDevice),
 		rest.Put("/api/0.0.1/device/deployments/:id/status",
 			controller.PutDeploymentStatusForDevice),
 		rest.Get("/api/0.0.1/deployments/:id/devices",

--- a/utils/testing/conversion.go
+++ b/utils/testing/conversion.go
@@ -15,10 +15,10 @@
 package testing
 
 func ErrorToErrStruct(err error) interface{} {
-	return struct{
-		Error string `json:"error"`
+	return struct {
+		Error     string `json:"error"`
 		RequestId string `json:"request_id"`
-	} {
+	}{
 		err.Error(),
 		"test",
 	}

--- a/utils/testing/conversion_external_test.go
+++ b/utils/testing/conversion_external_test.go
@@ -24,10 +24,10 @@ import (
 
 func TestErrorToErrStruct(t *testing.T) {
 	errStr := "ala ma kota"
-	assert.Equal(t, struct{
-		Error string `json:"error"`
+	assert.Equal(t, struct {
+		Error     string `json:"error"`
 		RequestId string `json:"request_id"`
-	} {
+	}{
 		errStr,
 		"test",
 	}, ErrorToErrStruct(errors.New(errStr)))


### PR DESCRIPTION
@mendersoftware/rndity @maciejmrowiec 

Although [MEN-744](https://tracker.mender.io/browse/MEN-744) mentions that the device is supposed to send both `artifact` and `device_type`, I have not found any use for `device_type` in the API handler. Feel free to point out the reasons why `device_type` is needed.