### PR TITLE
Simplify reading artifact file.

### DIFF
--- a/resources/images/controller/images_external_test.go
+++ b/resources/images/controller/images_external_test.go
@@ -392,7 +392,7 @@ func TestSoftwareImagesControllerNewImage(t *testing.T) {
 			InputModelID:     "1234",
 			JSONResponseParams: h.JSONResponseParams{
 				OutputStatus:     http.StatusBadRequest,
-				OutputBodyObject: h.ErrorToErrStruct(errors.New("info error: reader: error reading archive: unexpected EOF")),
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("reading artifact error: reader: error reading archive: unexpected EOF")),
 			},
 		},
 		{


### PR DESCRIPTION
There is no need to read each part of artifact separately in this
context. It should be enough to read everything at once and copy
appropriate parts to `metaArtifact`.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>