### PR TITLE
support multiple artifact device types when creating deployment

### DIFF
--- a/resources/images/mongo/dbsetup_test.go
+++ b/resources/images/mongo/dbsetup_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"gopkg.in/mgo.v2/dbtest"
+)
+
+var db *dbtest.DBServer
+
+// Overwrites test execution and allows for test database setup
+func TestMain(m *testing.M) {
+
+	dbdir, _ := ioutil.TempDir("", "dbsetup-test")
+	// os.Exit would ignore defers, workaround
+	status := func() int {
+		// Start test database server
+		db = &dbtest.DBServer{}
+		db.SetPath(dbdir)
+		// Tear down databaser server
+		// Note:
+		// if test panics, it will require manual database tier down
+		// testing package executes tests in goroutines therefore
+		// we can't catch panics issued in tests.
+		defer os.RemoveAll(dbdir)
+		defer db.Stop()
+		return m.Run()
+	}()
+
+	os.Exit(status)
+}

--- a/resources/images/mongo/images.go
+++ b/resources/images/mongo/images.go
@@ -29,9 +29,9 @@ const (
 	// Keys are corelated to field names in SoftwareImageMeta
 	// and SoftwareImageMetaArtifact structures
 	// Need to be kept in sync with that structure filed names
-	StorageKeySoftwareImageDeviceType = "meta_yocto.device_type"
-	StorageKeySoftwareImageName       = "meta.name"
-	StorageKeySoftwareImageId         = "_id"
+	StorageKeySoftwareImageDeviceTypes = "meta_yocto.device_types_compatible"
+	StorageKeySoftwareImageName        = "meta.name"
+	StorageKeySoftwareImageId          = "_id"
 )
 
 // Indexes
@@ -67,7 +67,7 @@ func (i *SoftwareImagesStorage) IndexStorage() error {
 	defer session.Close()
 
 	uniqueNameVersionIndex := mgo.Index{
-		Key:    []string{StorageKeySoftwareImageName, StorageKeySoftwareImageDeviceType},
+		Key:    []string{StorageKeySoftwareImageName, StorageKeySoftwareImageDeviceTypes},
 		Unique: true,
 		Name:   IndexUniqeNameAndDeviceTypeStr,
 		// Build index upfront - make sure this index is allways on.
@@ -134,8 +134,8 @@ func (i *SoftwareImagesStorage) ImageByNameAndDeviceType(name, deviceType string
 
 	// equal to device type & software version (application name + version)
 	query := bson.M{
-		StorageKeySoftwareImageDeviceType: deviceType,
-		StorageKeySoftwareImageName:       name,
+		StorageKeySoftwareImageDeviceTypes: deviceType,
+		StorageKeySoftwareImageName:        name,
 	}
 
 	session := i.session.Copy()

--- a/resources/images/mongo/images_test.go
+++ b/resources/images/mongo/images_test.go
@@ -12,4 +12,140 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-package mongo
+package mongo_test
+
+import (
+	"github.com/mendersoftware/deployments/resources/images"
+	model "github.com/mendersoftware/deployments/resources/images/model"
+	. "github.com/mendersoftware/deployments/resources/images/mongo"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSoftwareImagesStorageImageByNameAndDeviceType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestDeploymentStorageImageByNameAndDeviceType in short mode.")
+	}
+
+	//image dataset - common for all cases
+	inputImgs := []interface{}{
+		&images.SoftwareImage{
+			Id: "1",
+			SoftwareImageMetaConstructor: images.SoftwareImageMetaConstructor{
+				Name:        "App1 v1.0",
+				Description: "description",
+			},
+
+			SoftwareImageMetaArtifactConstructor: images.SoftwareImageMetaArtifactConstructor{
+				ArtifactName:          "app1-v1.0",
+				DeviceTypesCompatible: []string{"foo"},
+				Updates:               []images.Update{},
+			},
+		},
+		&images.SoftwareImage{
+			Id: "2",
+			SoftwareImageMetaConstructor: images.SoftwareImageMetaConstructor{
+				Name:        "App2 v0.1",
+				Description: "description",
+			},
+
+			SoftwareImageMetaArtifactConstructor: images.SoftwareImageMetaArtifactConstructor{
+				ArtifactName:          "app2-v0.1",
+				DeviceTypesCompatible: []string{"bar", "baz"},
+				Updates:               []images.Update{},
+			},
+		},
+	}
+
+	//setup db - common for all cases
+	db.Wipe()
+	session := db.Session()
+	defer session.Close()
+
+	coll := session.DB(DatabaseName).C(CollectionImages)
+	assert.NoError(t, coll.Insert(inputImgs...))
+
+	testCases := map[string]struct {
+		InputImageName string
+		InputDevType   string
+
+		OutputImage *images.SoftwareImage
+		OutputError error
+	}{
+		"name and dev type ok - single type": {
+			InputImageName: "App1 v1.0",
+			InputDevType:   "foo",
+
+			OutputImage: inputImgs[0].(*images.SoftwareImage),
+			OutputError: nil,
+		},
+		"name and dev type ok - multiple types": {
+			InputImageName: "App2 v0.1",
+			InputDevType:   "bar",
+
+			OutputImage: inputImgs[1].(*images.SoftwareImage),
+			OutputError: nil,
+		},
+		"name ok, dev type incompatible - single type": {
+			InputImageName: "App1 v1.0",
+			InputDevType:   "baz",
+
+			OutputImage: nil,
+			OutputError: nil,
+		},
+		"name ok, dev type incompatible - multiple types": {
+			InputImageName: "App2 v0.1",
+			InputDevType:   "foo",
+
+			OutputImage: nil,
+			OutputError: nil,
+		},
+		"name not found, dev type not found": {
+			InputImageName: "App3 v0.1",
+			InputDevType:   "bah",
+
+			OutputImage: nil,
+			OutputError: nil,
+		},
+		"name validation error": {
+			InputImageName: "",
+			InputDevType:   "foo",
+
+			OutputImage: nil,
+			OutputError: model.ErrSoftwareImagesStorageInvalidName,
+		},
+		"dev type validation error": {
+			InputImageName: "App2 v0.1",
+			InputDevType:   "",
+
+			OutputImage: nil,
+			OutputError: model.ErrSoftwareImagesStorageInvalidDeviceType,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Logf("testing case %s", name)
+		var res []images.SoftwareImage
+		err := coll.Find(nil).All(&res)
+		t.Logf("DEBUG inserted imgs %v", res)
+
+		store := NewSoftwareImagesStorage(session)
+
+		img, err := store.ImageByNameAndDeviceType(tc.InputImageName, tc.InputDevType)
+		t.Logf("DEBUG got img %v", img)
+
+		if tc.OutputError != nil {
+			assert.EqualError(t, err, tc.OutputError.Error())
+		} else {
+			assert.NoError(t, err)
+
+			if tc.OutputImage == nil {
+				assert.Nil(t, img)
+			} else {
+				assert.NotNil(t, img)
+				assert.Equal(t, *tc.OutputImage, *img)
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-721

`meta_yocto.device_type` becomes `meta_yocto.device_types_compatible`.- that's the only change.

note that mongo doesn't care if it matches a single value or an array of values; the latter has 'select if any element matches' semantics.

 @bboozzoo @kjaskiewiczz @maciejmrowiec 

