### PR TITLE
Artifact upload handling changed: temoporary file not used anymore

### DIFF
--- a/resources/images/controller/images_external_test.go
+++ b/resources/images/controller/images_external_test.go
@@ -87,7 +87,7 @@ func (fim *fakeImageModeler) DeleteImage(imageID string) error {
 }
 
 func (fim *fakeImageModeler) CreateImage(
-	imageFile *os.File,
+	artifact io.Reader,
 	metaConstructor *images.SoftwareImageMetaConstructor,
 	metaArtifactConstructor *images.SoftwareImageMetaArtifactConstructor) (string, error) {
 	return "", nil
@@ -463,7 +463,10 @@ func TestSoftwareImagesControllerNewImage(t *testing.T) {
 
 		model.On(
 			"CreateImage",
-			mock.AnythingOfType("*os.File"),
+			mock.MatchedBy(func(ir interface{}) bool {
+				_, ok := ir.(io.Reader)
+				return ok
+			}),
 			mock.AnythingOfType("*images.SoftwareImageMetaConstructor"),
 			mock.AnythingOfType("*images.SoftwareImageMetaArtifactConstructor")).
 			Return(testCase.InputModelID, testCase.InputModelError)

--- a/resources/images/controller/images_model.go
+++ b/resources/images/controller/images_model.go
@@ -16,7 +16,7 @@ package controller
 
 import (
 	"errors"
-	"os"
+	"io"
 	"time"
 
 	"github.com/mendersoftware/deployments/resources/images"
@@ -38,7 +38,7 @@ type ImagesModel interface {
 	GetImage(id string) (*images.SoftwareImage, error)
 	DeleteImage(imageID string) error
 	CreateImage(
-		imageFile *os.File,
+		artifact io.Reader,
 		metaConstructor *images.SoftwareImageMetaConstructor,
 		metaArtifactConstructor *images.SoftwareImageMetaArtifactConstructor) (string, error)
 	EditImage(id string, constructorData *images.SoftwareImageMetaConstructor) (bool, error)

--- a/resources/images/controller/mocks/ImagesModel.go
+++ b/resources/images/controller/mocks/ImagesModel.go
@@ -15,7 +15,7 @@
 package mocks
 
 import (
-	"os"
+	"io"
 	"time"
 
 	"github.com/mendersoftware/deployments/resources/images"
@@ -29,22 +29,22 @@ type ImagesModel struct {
 
 // CreateImage provides a mock function with given fields: constructorData
 func (_m *ImagesModel) CreateImage(
-	imageFile *os.File,
+	artifactReader io.Reader,
 	metaConstructor *images.SoftwareImageMetaConstructor,
 	metaArtifactConstructor *images.SoftwareImageMetaArtifactConstructor) (string, error) {
 
-	ret := _m.Called(imageFile, metaConstructor, metaArtifactConstructor)
+	ret := _m.Called(artifactReader, metaConstructor, metaArtifactConstructor)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(*os.File, *images.SoftwareImageMetaConstructor, *images.SoftwareImageMetaArtifactConstructor) string); ok {
-		r0 = rf(imageFile, metaConstructor, metaArtifactConstructor)
+	if rf, ok := ret.Get(0).(func(io.Reader, *images.SoftwareImageMetaConstructor, *images.SoftwareImageMetaArtifactConstructor) string); ok {
+		r0 = rf(artifactReader, metaConstructor, metaArtifactConstructor)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*os.File, *images.SoftwareImageMetaConstructor, *images.SoftwareImageMetaArtifactConstructor) error); ok {
-		r1 = rf(imageFile, metaConstructor, metaArtifactConstructor)
+	if rf, ok := ret.Get(1).(func(io.Reader, *images.SoftwareImageMetaConstructor, *images.SoftwareImageMetaArtifactConstructor) error); ok {
+		r1 = rf(artifactReader, metaConstructor, metaArtifactConstructor)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/resources/images/model/file_storage.go
+++ b/resources/images/model/file_storage.go
@@ -16,7 +16,7 @@ package model
 
 import (
 	"errors"
-	"os"
+	"io"
 	"time"
 
 	"github.com/mendersoftware/deployments/resources/images"
@@ -34,5 +34,5 @@ type FileStorage interface {
 	LastModified(objectId string) (time.Time, error)
 	PutRequest(objectId string, duration time.Duration) (*images.Link, error)
 	GetRequest(objectId string, duration time.Duration, responseContentType string) (*images.Link, error)
-	PutFile(objectId string, image *os.File, contentType string) error
+	UploadArtifact(objectId string, artifact io.Reader, contentType string) error
 }

--- a/resources/images/model/images.go
+++ b/resources/images/model/images.go
@@ -15,7 +15,7 @@
 package model
 
 import (
-	"os"
+	"io"
 	"time"
 
 	"github.com/mendersoftware/deployments/resources/images"
@@ -46,7 +46,7 @@ func NewImagesModel(
 }
 
 func (i *ImagesModel) CreateImage(
-	imageFile *os.File,
+	artifact io.Reader,
 	metaConstructor *images.SoftwareImageMetaConstructor,
 	metaArtifactConstructor *images.SoftwareImageMetaArtifactConstructor) (string, error) {
 
@@ -75,7 +75,7 @@ func (i *ImagesModel) CreateImage(
 		return "", errors.Wrap(err, "Fail to store the metadata")
 	}
 
-	if err := i.fileStorage.PutFile(image.Id, imageFile, ImageContentType); err != nil {
+	if err := i.fileStorage.UploadArtifact(image.Id, artifact, ImageContentType); err != nil {
 		i.imagesStorage.Delete(image.Id)
 		return "", errors.Wrap(err, "Fail to store the image")
 	}


### PR DESCRIPTION
Artifact upload handling changed.

Old approach:
- whole artifact file is uploaded to backed and saved in temporary file;
- artifact from temp file is uploaded to the file server.

New approach:
- metadata is read into local buffer;
- local buffer with metadata and rest of the uploaded file are uploaded to file server.

@bboozzoo @maciejmrowiec @mchalski