### PR TITLE
storage backend certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ RUN apk update && apk upgrade && \
      apk add ca-certificates && \
      rm -rf /var/cache/apk/*
 
-COPY ./deployments /usr/bin/
-
 RUN mkdir /etc/deployments
+
 COPY ./config.yaml /etc/deployments/
 
 ENTRYPOINT ["/usr/bin/deployments", "-config", "/etc/deployments/config.yaml"]
+
+COPY ./deployments /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN mkdir /etc/deployments
 
 COPY ./config.yaml /etc/deployments/
 
-ENTRYPOINT ["/usr/bin/deployments", "-config", "/etc/deployments/config.yaml"]
+ENTRYPOINT ["/entrypoint.sh"]
 
+COPY ./entrypoint.sh /entrypoint.sh
 COPY ./deployments /usr/bin/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+CERTS_DIR=/etc/ssl/certs
+CERTS_BUNDLE=$CERTS_DIR/ca-certificates.crt
+
+if [ -n "$STORAGE_BACKEND_CERT" -a -e "$STORAGE_BACKEND_CERT" ]; then
+    cat "$STORAGE_BACKEND_CERT" >> $CERTS_BUNDLE
+    wheredir=$(dirname "$STORAGE_BACKEND_CERT")
+    if [ "$wheredir" != $CERTS_DIR ]; then
+        cp "$STORAGE_BACKEND_CERT" $CERTS_DIR
+    fi
+    # storage certificate may or may not have been in CERTS_DIR already, just to
+    # be safe, run c_rehash so that other tools work too
+    c_rehash $CERTS_DIR
+fi
+
+exec /usr/bin/deployments -config /etc/deployments/config.yaml "$@"


### PR DESCRIPTION
Use custom entrypoint that sets up storage backend certificate if required.

We're using the fact that Golang's HTTPS client will access system default location when loading up x509 trust store.

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 