### PR TITLE
Make S3 region configurable via environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func HandleConfigFile(filePath string) (config.ConfigReader, error) {
 	c.BindEnv(SettingAwsAuthKeyId, "AWS_ACCESS_KEY_ID")
 	c.BindEnv(SettingAwsAuthSecret, "AWS_SECRET_ACCESS_KEY")
 	c.BindEnv(SettingAwsAuthToken, "AWS_SESSION_TOKEN")
+	c.BindEnv(SettingAwsS3Region, "AWS_REGION")
 
 	// Enable setting also other conig values by environment variables
 	c.SetEnvPrefix("DEPLOYMENTS")


### PR DESCRIPTION
This is a useful in general, and I need it for testing :)

I want to be able to set the AWS region using an environment variable with docker-compose. The only other way would be to modify the config of the deployments config file. 