### PR TITLE
Upload handling changed.

### DIFF
--- a/resources/deployments/controller/controller_deployments_external_test.go
+++ b/resources/deployments/controller/controller_deployments_external_test.go
@@ -44,6 +44,8 @@ import (
 // 			they are more of integration test beween controller and view
 //			testing actuall HTTP endpoint input/reponse
 
+const validUUIDv4 = "d50eda0d-2cea-4de1-8d42-9cd3e7e8670d"
+
 func makeDeviceAuthHeader(claim string) string {
 	return fmt.Sprintf("Bearer foo.%s.bar",
 		base64.StdEncoding.EncodeToString([]byte(claim)))
@@ -66,6 +68,7 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 	t.Parallel()
 
 	image := images.NewSoftwareImage(
+		validUUIDv4,
 		&images.SoftwareImageMetaConstructor{
 			Name:        "foo-image",
 			Description: "foo-image-desc",

--- a/resources/deployments/model/deployments_external_test.go
+++ b/resources/deployments/model/deployments_external_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+const validUUIDv4 = "d50eda0d-2cea-4de1-8d42-9cd3e7e8670d"
+
 func TestDeploymentModelGetDeployment(t *testing.T) {
 
 	t.Parallel()
@@ -190,6 +192,7 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 	t.Parallel()
 
 	image := images.NewSoftwareImage(
+		validUUIDv4,
 		&images.SoftwareImageMetaConstructor{
 			Name: "foo",
 		},
@@ -230,6 +233,7 @@ func TestDeploymentModelGetDeploymentForDevice(t *testing.T) {
 			InputID: "ID:123",
 			InputOlderstDeviceDeployment: &deployments.DeviceDeployment{
 				Image: images.NewSoftwareImage(
+					validUUIDv4,
 					&images.SoftwareImageMetaConstructor{
 						Name: "foo",
 					},

--- a/resources/images/controller/images_model.go
+++ b/resources/images/controller/images_model.go
@@ -26,8 +26,10 @@ import (
 var (
 	ErrImageMetaNotFound             = errors.New("Image metadata is not found")
 	ErrModelMissingInputMetadata     = errors.New("Missing input metadata")
+	ErrModelMissingInputArtifact     = errors.New("Missing input artifact")
 	ErrModelInvalidMetadata          = errors.New("Metadata invalid")
 	ErrModelArtifactNotUnique        = errors.New("Artifact not unique")
+	ErrModelArtifactUploadFailed     = errors.New("Failed to upload the artifact")
 	ErrModelImageInActiveDeployment  = errors.New("Image is used in active deployment and cannot be removed")
 	ErrModelImageUsedInAnyDeployment = errors.New("Image have been already used in deployment")
 )
@@ -38,8 +40,7 @@ type ImagesModel interface {
 	GetImage(id string) (*images.SoftwareImage, error)
 	DeleteImage(imageID string) error
 	CreateImage(
-		artifact io.Reader,
 		metaConstructor *images.SoftwareImageMetaConstructor,
-		metaArtifactConstructor *images.SoftwareImageMetaArtifactConstructor) (string, error)
+		image io.Reader) (string, error)
 	EditImage(id string, constructorData *images.SoftwareImageMetaConstructor) (bool, error)
 }

--- a/resources/images/controller/mocks/ImagesModel.go
+++ b/resources/images/controller/mocks/ImagesModel.go
@@ -29,22 +29,21 @@ type ImagesModel struct {
 
 // CreateImage provides a mock function with given fields: constructorData
 func (_m *ImagesModel) CreateImage(
-	artifactReader io.Reader,
 	metaConstructor *images.SoftwareImageMetaConstructor,
-	metaArtifactConstructor *images.SoftwareImageMetaArtifactConstructor) (string, error) {
+	artifactReader io.Reader) (string, error) {
 
-	ret := _m.Called(artifactReader, metaConstructor, metaArtifactConstructor)
+	ret := _m.Called(metaConstructor, artifactReader)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(io.Reader, *images.SoftwareImageMetaConstructor, *images.SoftwareImageMetaArtifactConstructor) string); ok {
-		r0 = rf(artifactReader, metaConstructor, metaArtifactConstructor)
+	if rf, ok := ret.Get(0).(func(*images.SoftwareImageMetaConstructor, io.Reader) string); ok {
+		r0 = rf(metaConstructor, artifactReader)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(io.Reader, *images.SoftwareImageMetaConstructor, *images.SoftwareImageMetaArtifactConstructor) error); ok {
-		r1 = rf(artifactReader, metaConstructor, metaArtifactConstructor)
+	if rf, ok := ret.Get(1).(func(*images.SoftwareImageMetaConstructor, io.Reader) error); ok {
+		r1 = rf(metaConstructor, artifactReader)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/resources/images/image.go
+++ b/resources/images/image.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/asaskevich/govalidator"
-	"github.com/satori/go.uuid"
 )
 
 // Informations provided by the user
@@ -122,13 +121,13 @@ type SoftwareImage struct {
 	Modified *time.Time `json:"modified" valid:"_"`
 }
 
-// NewSoftwareImage create new software image object.
+// NewSoftwareImage creates new software image object.
 func NewSoftwareImage(
+	id string,
 	metaConstructor *SoftwareImageMetaConstructor,
 	metaArtifactConstructor *SoftwareImageMetaArtifactConstructor) *SoftwareImage {
 
 	now := time.Now()
-	id := uuid.NewV4().String()
 
 	return &SoftwareImage{
 		SoftwareImageMetaConstructor:         *metaConstructor,

--- a/resources/images/image_test.go
+++ b/resources/images/image_test.go
@@ -16,6 +16,8 @@ package images
 
 import "testing"
 
+const validUUIDv4 = "d50eda0d-2cea-4de1-8d42-9cd3e7e8670d"
+
 func TestValidateEmptyImageMeta(t *testing.T) {
 	image := NewSoftwareImageMetaConstructor()
 
@@ -68,7 +70,7 @@ func TestValidateCorrectImage(t *testing.T) {
 	imageMetaArtifact.DeviceTypesCompatible = []string{"required"}
 	imageMeta.Name = required
 
-	image := NewSoftwareImage(imageMeta, imageMetaArtifact)
+	image := NewSoftwareImage(validUUIDv4, imageMeta, imageMetaArtifact)
 
 	if err := image.Validate(); err != nil {
 		t.FailNow()


### PR DESCRIPTION
Artifact uploaded to the deployments service will be uploaded to file
storage using presigned link and parsed by artifact library concurrently.
The solution is based on the io.TeeReader and io.Pipe.
Both operations needs to be done in the concurrent goroutines because
reading from the Pipe is a blocking operation.

@bboozzoo @maciejmrowiec @mchalski  