### PR TITLE
deployments: controller: device API: make artifact_name and device_type required

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -41,12 +41,12 @@ paths:
           description: Contains the JWT token issued by the Device Authentication Service.
         - name: artifact_name
           in: query
-          required: false
+          required: true
           type: string
           description: currently installed artifact
         - name: device_type
           in: query
-          required: false
+          required: true
           type: string
           description: Device type of device
       produces:

--- a/resources/deployments/controller/controller_deployments.go
+++ b/resources/deployments/controller/controller_deployments.go
@@ -194,6 +194,11 @@ func (d *DeploymentsController) GetDeploymentForDevice(w rest.ResponseWriter, r 
 		DeviceType: q.Get(GetDeploymentForDeviceQueryDeviceType),
 	}
 
+	if err := installed.Validate(); err != nil {
+		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
+		return
+	}
+
 	deployment, err := d.model.GetDeploymentForDeviceWithCurrent(idata.Subject, installed)
 	if err != nil {
 		d.view.RenderInternalError(w, r, err, l)

--- a/resources/deployments/controller/controller_deployments_external_test.go
+++ b/resources/deployments/controller/controller_deployments_external_test.go
@@ -116,6 +116,15 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 			Headers: map[string]string{
 				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-1"}`),
 			},
+
+			InputModelCurrentDeployment: deployments.InstalledDeviceDeployment{
+				Artifact:   "artifact-name",
+				DeviceType: "hammer",
+			},
+			Params: url.Values{
+				GetDeploymentForDeviceQueryArtifact:   []string{"artifact-name"},
+				GetDeploymentForDeviceQueryDeviceType: []string{"hammer"},
+			},
 		},
 		{
 			InputID: "device-id-2",
@@ -124,6 +133,14 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 			},
 			Headers: map[string]string{
 				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-2"}`),
+			},
+			InputModelCurrentDeployment: deployments.InstalledDeviceDeployment{
+				Artifact:   "artifact-name",
+				DeviceType: "hammer",
+			},
+			Params: url.Values{
+				GetDeploymentForDeviceQueryArtifact:   []string{"artifact-name"},
+				GetDeploymentForDeviceQueryDeviceType: []string{"hammer"},
 			},
 		},
 		{
@@ -151,6 +168,14 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 			Headers: map[string]string{
 				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-3"}`),
 			},
+			InputModelCurrentDeployment: deployments.InstalledDeviceDeployment{
+				Artifact:   "artifact-name",
+				DeviceType: "hammer",
+			},
+			Params: url.Values{
+				GetDeploymentForDeviceQueryArtifact:   []string{"artifact-name"},
+				GetDeploymentForDeviceQueryDeviceType: []string{"hammer"},
+			},
 		},
 		{
 			InputID: "device-id-3",
@@ -170,6 +195,48 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 			},
 			Headers: map[string]string{
 				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-3"}`),
+			},
+		},
+		{
+			InputID: "device-id-4",
+			InputModelDeploymentInstructions: nil,
+
+			JSONResponseParams: h.JSONResponseParams{
+				OutputStatus:     http.StatusBadRequest,
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("Artifact: non zero value required;")),
+			},
+			Params: url.Values{
+				GetDeploymentForDeviceQueryDeviceType: []string{"hammer"},
+			},
+			Headers: map[string]string{
+				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-4"}`),
+			},
+		},
+		{
+			InputID: "device-id-5",
+			InputModelDeploymentInstructions: nil,
+
+			JSONResponseParams: h.JSONResponseParams{
+				OutputStatus:     http.StatusBadRequest,
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("DeviceType: non zero value required;")),
+			},
+			Params: url.Values{
+				GetDeploymentForDeviceQueryArtifact: []string{"artifact-name"},
+			},
+			Headers: map[string]string{
+				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-5"}`),
+			},
+		},
+		{
+			InputID: "device-id-6",
+			InputModelDeploymentInstructions: nil,
+
+			JSONResponseParams: h.JSONResponseParams{
+				OutputStatus:     http.StatusBadRequest,
+				OutputBodyObject: h.ErrorToErrStruct(errors.New("Artifact: non zero value required;DeviceType: non zero value required;")),
+			},
+			Headers: map[string]string{
+				"Authorization": makeDeviceAuthHeader(`{"sub": "device-id-6"}`),
 			},
 		},
 	}

--- a/resources/deployments/device_deployment.go
+++ b/resources/deployments/device_deployment.go
@@ -134,6 +134,11 @@ func ActiveDeploymentStatuses() []string {
 // InstalledDeviceDeployment describes a deployment currently installed on the
 // device, usually reported by a device
 type InstalledDeviceDeployment struct {
-	Artifact   string
-	DeviceType string
+	Artifact   string `valid:"required"`
+	DeviceType string `valid:"required"`
+}
+
+func (i *InstalledDeviceDeployment) Validate() error {
+	_, err := govalidator.ValidateStruct(i)
+	return err
 }


### PR DESCRIPTION
Make `artifact_name` and `device_type` required query parameters for
`/device/deployments/next` endpoint.

Fixes: [Mender #877]

@mendersoftware/rndity @maciejmrowiec

@GregorioDiStefano do you need to update any tests when this is merged?