### PR TITLE
MEN-878: Merge artifact_name and name during image uploads.

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -278,9 +278,8 @@ paths:
           description: OK
           examples:
             application/json:
-              - name: MySecretApp v2
+              - name: Application 1.0.0
                 description: Johns Monday test build
-                artifact_name: core-image-full-cmdline-20160330201408
                 device_types_compatible: [Beagle Bone]
                 id: 0c13a0e6-6b63-475d-8260-ee42a590e8ff
                 modified: "2016-03-11T13:03:17.063493443Z"
@@ -309,10 +308,6 @@ paths:
       consumes:
         - multipart/form-data
       parameters:
-        - name: name
-          in: formData
-          required: true
-          type: string
         - name: description
           in: formData
           required: false
@@ -354,9 +349,8 @@ paths:
           description: Successful response.
           examples:
             application/json:
-              name: MySecretApp v2
+              name: Application 1.0.0
               description: Johns Monday test build
-              artifact_name: core-image-full-cmdline-20160330201408
               device_types_compatible: [Beagle Bone]
               id: 0c13a0e6-6b63-475d-8260-ee42a590e8ff
               modified: "2016-03-11T13:03:17.063493443Z"
@@ -378,9 +372,9 @@ paths:
           $ref: "#/responses/InternalServerError"
 
     put:
-      summary: Update name and description of a selected artifact
+      summary: Update description of a selected artifact
       description: |
-        Edit artifact name and description. Artifact is not allowed to be edited if it was used
+        Edit description. Artifact is not allowed to be edited if it was used
         in any deployment.
       parameters:
         - name: id
@@ -625,15 +619,9 @@ definitions:
     description: Artifact information update.
     type: object
     properties:
-      name:
-        type: string
       description:
         type: string
-    required:
-      - name
-      - description
     example:
-      name: Artifact name
       description: Some description
   ArtifactTypeInfo:
       description: |
@@ -690,8 +678,6 @@ definitions:
         type: string
       description:
         type: string
-      artifact_name:
-        type: string
       device_types_compatible:
         type: array
         items:
@@ -713,15 +699,13 @@ definitions:
     required:
       - name
       - description
-      - artifact_name
       - device_types_compatible
       - id
       - modified
     example:
       application/json:
-        name: MySecretApp v2
+        name: Application 1.0.0
         description: Johns Monday test build
-        artifact_name: core-image-full-cmdline-20160330201408
         device_types_compatible: [Beagle Bone]
         id: 0c13a0e6-6b63-475d-8260-ee42a590e8ff
         modified: "2016-03-11T13:03:17.063493443Z"

--- a/resources/deployments/controller/controller_deployments_external_test.go
+++ b/resources/deployments/controller/controller_deployments_external_test.go
@@ -18,12 +18,13 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/Sirupsen/logrus"
 
 	"github.com/ant0ine/go-json-rest/rest"
 	"github.com/ant0ine/go-json-rest/rest/test"
@@ -70,11 +71,10 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 	image := images.NewSoftwareImage(
 		validUUIDv4,
 		&images.SoftwareImageMetaConstructor{
-			Name:        "foo-image",
 			Description: "foo-image-desc",
 		},
 		&images.SoftwareImageMetaArtifactConstructor{
-			ArtifactName: "artifact-name",
+			Name: "artifact-name",
 			DeviceTypesCompatible: []string{
 				"hammer",
 			},
@@ -134,7 +134,7 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 			InputModelDeploymentInstructions: &deployments.DeploymentInstructions{
 				ID: "foo-1",
 				Artifact: deployments.ArtifactDeploymentInstructions{
-					ArtifactName:          image.ArtifactName,
+					ArtifactName:          image.Name,
 					Source:                images.Link{},
 					DeviceTypesCompatible: image.DeviceTypesCompatible,
 				},
@@ -145,7 +145,7 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 				OutputBodyObject: &deployments.DeploymentInstructions{
 					ID: "foo-1",
 					Artifact: deployments.ArtifactDeploymentInstructions{
-						ArtifactName:          image.ArtifactName,
+						ArtifactName:          image.Name,
 						Source:                images.Link{},
 						DeviceTypesCompatible: image.DeviceTypesCompatible,
 					},
@@ -177,31 +177,33 @@ func TestControllerGetDeploymentForDevice(t *testing.T) {
 		},
 	}
 
-	for tidx, testCase := range testCases {
+	for testCaseNumber, testCase := range testCases {
 
-		t.Logf("testing input ID: %v tc: %d", testCase.InputID, tidx)
-		deploymentModel := new(mocks.DeploymentsModel)
-		deploymentModel.On("GetDeploymentForDeviceWithCurrent", testCase.InputID,
-			testCase.InputModelCurrentDeployment).
-			Return(testCase.InputModelDeploymentInstructions, testCase.InputModelError)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
 
-		router, err := rest.MakeRouter(
-			rest.Get("/r/update",
-				NewDeploymentsController(deploymentModel,
-					new(view.DeploymentsView)).GetDeploymentForDevice))
-		assert.NoError(t, err)
+			deploymentModel := new(mocks.DeploymentsModel)
+			deploymentModel.On("GetDeploymentForDeviceWithCurrent", testCase.InputID,
+				testCase.InputModelCurrentDeployment).
+				Return(testCase.InputModelDeploymentInstructions, testCase.InputModelError)
 
-		api := makeApi(router)
+			router, err := rest.MakeRouter(
+				rest.Get("/r/update",
+					NewDeploymentsController(deploymentModel,
+						new(view.DeploymentsView)).GetDeploymentForDevice))
+			assert.NoError(t, err)
 
-		vals := testCase.Params.Encode()
-		req := test.MakeSimpleRequest("GET", "http://localhost/r/update?"+vals, nil)
-		for k, v := range testCase.Headers {
-			req.Header.Set(k, v)
-		}
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			api := makeApi(router)
 
-		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			vals := testCase.Params.Encode()
+			req := test.MakeSimpleRequest("GET", "http://localhost/r/update?"+vals, nil)
+			for k, v := range testCase.Headers {
+				req.Header.Set(k, v)
+			}
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+		})
 	}
 }
 
@@ -259,25 +261,27 @@ func TestControllerGetDeployment(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Logf("testing %v", testCase.InputID)
+	for testCaseNumber, testCase := range testCases {
 
-		deploymentModel := new(mocks.DeploymentsModel)
-		deploymentModel.On("GetDeployment", testCase.InputID).
-			Return(testCase.InputModelDeployment, testCase.InputModelError)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
 
-		router, err := rest.MakeRouter(
-			rest.Get("/r/:id",
-				NewDeploymentsController(deploymentModel, new(view.DeploymentsView)).GetDeployment))
-		assert.NoError(t, err)
+			deploymentModel := new(mocks.DeploymentsModel)
+			deploymentModel.On("GetDeployment", testCase.InputID).
+				Return(testCase.InputModelDeployment, testCase.InputModelError)
 
-		api := makeApi(router)
+			router, err := rest.MakeRouter(
+				rest.Get("/r/:id",
+					NewDeploymentsController(deploymentModel, new(view.DeploymentsView)).GetDeployment))
+			assert.NoError(t, err)
 
-		req := test.MakeSimpleRequest("GET", "http://localhost/r/"+testCase.InputID, nil)
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			api := makeApi(router)
 
-		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			req := test.MakeSimpleRequest("GET", "http://localhost/r/"+testCase.InputID, nil)
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+		})
 	}
 }
 
@@ -334,25 +338,28 @@ func TestControllerPostDeployment(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
+	for testCaseNumber, testCase := range testCases {
 
-		deploymentModel := new(mocks.DeploymentsModel)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
 
-		deploymentModel.On("CreateDeployment", testCase.InputBodyObject).
-			Return(testCase.InputModelID, testCase.InputModelError)
+			deploymentModel := new(mocks.DeploymentsModel)
 
-		router, err := rest.MakeRouter(
-			rest.Post("/r",
-				NewDeploymentsController(deploymentModel, new(view.DeploymentsView)).PostDeployment))
-		assert.NoError(t, err)
+			deploymentModel.On("CreateDeployment", testCase.InputBodyObject).
+				Return(testCase.InputModelID, testCase.InputModelError)
 
-		api := makeApi(router)
+			router, err := rest.MakeRouter(
+				rest.Post("/r",
+					NewDeploymentsController(deploymentModel, new(view.DeploymentsView)).PostDeployment))
+			assert.NoError(t, err)
 
-		req := test.MakeSimpleRequest("POST", "http://localhost/r", testCase.InputBodyObject)
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			api := makeApi(router)
 
-		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			req := test.MakeSimpleRequest("POST", "http://localhost/r", testCase.InputBodyObject)
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+		})
 	}
 }
 
@@ -468,35 +475,35 @@ func TestControllerPutDeploymentStatus(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
+	for testCaseNumber, testCase := range testCases {
 
-		t.Logf("testing %s %s %s %v",
-			testCase.InputModelDeploymentID, testCase.InputModelDeviceID,
-			testCase.InputModelStatus, testCase.InputModelError)
-		deploymentModel := new(mocks.DeploymentsModel)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
 
-		deploymentModel.On("UpdateDeviceDeploymentStatus",
-			testCase.InputModelDeploymentID,
-			testCase.InputModelDeviceID, testCase.InputModelStatus).
-			Return(testCase.InputModelError)
+			deploymentModel := new(mocks.DeploymentsModel)
 
-		router, err := rest.MakeRouter(
-			rest.Post("/r/:id",
-				NewDeploymentsController(deploymentModel,
-					new(view.DeploymentsView)).PutDeploymentStatusForDevice))
-		assert.NoError(t, err)
+			deploymentModel.On("UpdateDeviceDeploymentStatus",
+				testCase.InputModelDeploymentID,
+				testCase.InputModelDeviceID, testCase.InputModelStatus).
+				Return(testCase.InputModelError)
 
-		api := makeApi(router)
+			router, err := rest.MakeRouter(
+				rest.Post("/r/:id",
+					NewDeploymentsController(deploymentModel,
+						new(view.DeploymentsView)).PutDeploymentStatusForDevice))
+			assert.NoError(t, err)
 
-		req := test.MakeSimpleRequest("POST", "http://localhost/r/"+testCase.InputModelDeploymentID,
-			testCase.InputBodyObject)
-		for k, v := range testCase.Headers {
-			req.Header.Set(k, v)
-		}
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			api := makeApi(router)
 
-		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			req := test.MakeSimpleRequest("POST", "http://localhost/r/"+testCase.InputModelDeploymentID,
+				testCase.InputBodyObject)
+			for k, v := range testCase.Headers {
+				req.Header.Set(k, v)
+			}
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+		})
 	}
 }
 
@@ -559,29 +566,31 @@ func TestControllerGetDeploymentStats(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
+	for testCaseNumber, testCase := range testCases {
 
-		t.Logf("testing %s %v", testCase.InputModelDeploymentID, testCase.InputModelError)
-		deploymentModel := new(mocks.DeploymentsModel)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
 
-		deploymentModel.On("GetDeploymentStats", testCase.InputModelDeploymentID).
-			Return(testCase.InputModelStats, testCase.InputModelError)
+			deploymentModel := new(mocks.DeploymentsModel)
 
-		router, err := rest.MakeRouter(
-			rest.Post("/r/:id",
-				NewDeploymentsController(deploymentModel,
-					new(view.DeploymentsView)).GetDeploymentStats))
+			deploymentModel.On("GetDeploymentStats", testCase.InputModelDeploymentID).
+				Return(testCase.InputModelStats, testCase.InputModelError)
 
-		assert.NoError(t, err)
+			router, err := rest.MakeRouter(
+				rest.Post("/r/:id",
+					NewDeploymentsController(deploymentModel,
+						new(view.DeploymentsView)).GetDeploymentStats))
 
-		api := makeApi(router)
+			assert.NoError(t, err)
 
-		req := test.MakeSimpleRequest("POST", "http://localhost/r/"+testCase.InputModelDeploymentID,
-			nil)
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			api := makeApi(router)
 
-		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			req := test.MakeSimpleRequest("POST", "http://localhost/r/"+testCase.InputModelDeploymentID,
+				nil)
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+		})
 	}
 }
 
@@ -641,26 +650,28 @@ func TestControllerGetDeviceStatusesForDeployment(t *testing.T) {
 		},
 	}
 
-	for id, tc := range testCases {
-		t.Logf("test case: %s", id)
+	for caseName, tc := range testCases {
 
-		deploymentModel := new(mocks.DeploymentsModel)
-		deploymentModel.On("GetDeviceStatusesForDeployment", tc.deploymentID).
-			Return(tc.modelStatuses, tc.modelErr)
+		t.Run(caseName, func(t *testing.T) {
 
-		router, err := rest.MakeRouter(
-			rest.Get("/r/:id",
-				NewDeploymentsController(deploymentModel, new(view.DeploymentsView)).GetDeviceStatusesForDeployment))
+			deploymentModel := new(mocks.DeploymentsModel)
+			deploymentModel.On("GetDeviceStatusesForDeployment", tc.deploymentID).
+				Return(tc.modelStatuses, tc.modelErr)
 
-		assert.NoError(t, err)
+			router, err := rest.MakeRouter(
+				rest.Get("/r/:id",
+					NewDeploymentsController(deploymentModel, new(view.DeploymentsView)).GetDeviceStatusesForDeployment))
 
-		api := makeApi(router)
+			assert.NoError(t, err)
 
-		req := test.MakeSimpleRequest("GET", "http://localhost/r/"+tc.deploymentID, nil)
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			api := makeApi(router)
 
-		h.CheckRecordedResponse(t, recorded, tc.JSONResponseParams)
+			req := test.MakeSimpleRequest("GET", "http://localhost/r/"+tc.deploymentID, nil)
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, tc.JSONResponseParams)
+		})
 	}
 }
 
@@ -766,40 +777,41 @@ func TestControllerLookupDeployment(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
+	for testCaseNumber, testCase := range testCases {
 
-		t.Logf("testing %+v %s", testCase.InputModelQuery, testCase.InputModelError)
-		deploymentModel := new(mocks.DeploymentsModel)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
 
-		deploymentModel.On("LookupDeployment", testCase.InputModelQuery).
-			Return(testCase.InputModelDeployments, testCase.InputModelError)
+			deploymentModel := new(mocks.DeploymentsModel)
 
-		router, err := rest.MakeRouter(
-			rest.Get("/r",
-				NewDeploymentsController(deploymentModel,
-					new(view.DeploymentsView)).LookupDeployment))
+			deploymentModel.On("LookupDeployment", testCase.InputModelQuery).
+				Return(testCase.InputModelDeployments, testCase.InputModelError)
 
-		assert.NoError(t, err)
+			router, err := rest.MakeRouter(
+				rest.Get("/r",
+					NewDeploymentsController(deploymentModel,
+						new(view.DeploymentsView)).LookupDeployment))
 
-		api := makeApi(router)
+			assert.NoError(t, err)
 
-		u := url.URL{
-			Scheme: "http",
-			Host:   "localhost",
-			Path:   "/r",
-		}
-		q := u.Query()
-		q.Set("search", testCase.InputModelQuery.SearchText)
-		if testCase.SearchStatus != "" {
-			q.Set("status", testCase.SearchStatus)
-		}
-		u.RawQuery = q.Encode()
-		t.Logf("query: %s", u.String())
-		req := test.MakeSimpleRequest("GET", u.String(), nil)
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			api := makeApi(router)
 
-		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			u := url.URL{
+				Scheme: "http",
+				Host:   "localhost",
+				Path:   "/r",
+			}
+			q := u.Query()
+			q.Set("search", testCase.InputModelQuery.SearchText)
+			if testCase.SearchStatus != "" {
+				q.Set("status", testCase.SearchStatus)
+			}
+			u.RawQuery = q.Encode()
+			req := test.MakeSimpleRequest("GET", u.String(), nil)
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+		})
 	}
 }
 
@@ -872,16 +884,19 @@ func TestParseLookupQuery(t *testing.T) {
 			},
 		},
 	}
-	for _, tc := range testCases {
-		t.Logf("testing: %v", tc.vals)
 
-		q, err := ParseLookupQuery(tc.vals)
-		if tc.err != nil {
-			assert.Error(t, err)
-			assert.EqualError(t, tc.err, err.Error())
-		} else {
-			assert.Equal(t, tc.query, q)
-		}
+	for testCaseNumber, tc := range testCases {
+
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
+
+			q, err := ParseLookupQuery(tc.vals)
+			if tc.err != nil {
+				assert.Error(t, err)
+				assert.EqualError(t, tc.err, err.Error())
+			} else {
+				assert.Equal(t, tc.query, q)
+			}
+		})
 	}
 }
 
@@ -902,6 +917,7 @@ func TestControllerPutDeploymentLog(t *testing.T) {
 			Level:     "notice",
 		},
 	}
+
 	testCases := []struct {
 		h.JSONResponseParams
 		InputBodyObject interface{}
@@ -998,35 +1014,36 @@ func TestControllerPutDeploymentLog(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Logf("testing %s %s %v %v",
-			testCase.InputModelDeploymentID, testCase.InputModelDeviceID,
-			testCase.InputBodyObject, testCase.InputModelError)
-		deploymentModel := new(mocks.DeploymentsModel)
+	for testCaseNumber, testCase := range testCases {
 
-		deploymentModel.On("SaveDeviceDeploymentLog",
-			testCase.InputModelDeviceID,
-			testCase.InputModelDeploymentID,
-			testCase.InputModelMessages).
-			Return(testCase.InputModelError)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
 
-		router, err := rest.MakeRouter(
-			rest.Put("/r/:id",
-				NewDeploymentsController(deploymentModel,
-					new(view.DeploymentsView)).PutDeploymentLogForDevice))
-		assert.NoError(t, err)
+			deploymentModel := new(mocks.DeploymentsModel)
 
-		api := makeApi(router)
+			deploymentModel.On("SaveDeviceDeploymentLog",
+				testCase.InputModelDeviceID,
+				testCase.InputModelDeploymentID,
+				testCase.InputModelMessages).
+				Return(testCase.InputModelError)
 
-		req := test.MakeSimpleRequest("PUT", "http://localhost/r/"+testCase.InputModelDeploymentID,
-			testCase.InputBodyObject)
-		for k, v := range testCase.Headers {
-			req.Header.Set(k, v)
-		}
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			router, err := rest.MakeRouter(
+				rest.Put("/r/:id",
+					NewDeploymentsController(deploymentModel,
+						new(view.DeploymentsView)).PutDeploymentLogForDevice))
+			assert.NoError(t, err)
 
-		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			api := makeApi(router)
+
+			req := test.MakeSimpleRequest("PUT", "http://localhost/r/"+testCase.InputModelDeploymentID,
+				testCase.InputBodyObject)
+			for k, v := range testCase.Headers {
+				req.Header.Set(k, v)
+			}
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+		})
 	}
 }
 
@@ -1126,38 +1143,37 @@ func TestControllerGetDeploymentLog(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Logf("testing %s %s %v",
-			testCase.InputModelDeploymentID, testCase.InputModelDeviceID,
-			testCase.InputModelError)
-		deploymentModel := new(mocks.DeploymentsModel)
+	for testCaseNumber, testCase := range testCases {
 
-		deploymentModel.On("GetDeviceDeploymentLog",
-			testCase.InputModelDeviceID,
-			testCase.InputModelDeploymentID).
-			Return(testCase.InputModelDeploymentLog, testCase.InputModelError)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
+			deploymentModel := new(mocks.DeploymentsModel)
 
-		router, err := rest.MakeRouter(
-			rest.Get("/r/:id/:devid",
-				NewDeploymentsController(deploymentModel,
-					new(view.DeploymentsView)).GetDeploymentLogForDevice))
-		assert.NoError(t, err)
+			deploymentModel.On("GetDeviceDeploymentLog",
+				testCase.InputModelDeviceID,
+				testCase.InputModelDeploymentID).
+				Return(testCase.InputModelDeploymentLog, testCase.InputModelError)
 
-		api := makeApi(router)
+			router, err := rest.MakeRouter(
+				rest.Get("/r/:id/:devid",
+					NewDeploymentsController(deploymentModel,
+						new(view.DeploymentsView)).GetDeploymentLogForDevice))
+			assert.NoError(t, err)
 
-		req := test.MakeSimpleRequest("GET", "http://localhost/r/"+
-			testCase.InputModelDeploymentID+"/"+testCase.InputModelDeviceID,
-			nil)
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
-		if testCase.JSONResponseParams.OutputStatus != http.StatusOK {
-			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
-		} else {
-			assert.Equal(t, testCase.Body, recorded.Recorder.Body.String())
-			assert.Equal(t, http.StatusOK, recorded.Recorder.Code)
-			assert.Equal(t, "text/plain", recorded.Recorder.HeaderMap.Get("Content-Type"))
-			t.Logf("content:\n%s", recorded.Recorder.Body)
-		}
+			api := makeApi(router)
+
+			req := test.MakeSimpleRequest("GET", "http://localhost/r/"+
+				testCase.InputModelDeploymentID+"/"+testCase.InputModelDeviceID,
+				nil)
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+			if testCase.JSONResponseParams.OutputStatus != http.StatusOK {
+				h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			} else {
+				assert.Equal(t, testCase.Body, recorded.Recorder.Body.String())
+				assert.Equal(t, http.StatusOK, recorded.Recorder.Code)
+				assert.Equal(t, "text/plain", recorded.Recorder.HeaderMap.Get("Content-Type"))
+			}
+		})
 	}
 }
 
@@ -1243,33 +1259,32 @@ func TestControllerAbortDeployment(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
+	for testCaseNumber, testCase := range testCases {
 
-		t.Logf("testing %s %s %t %v %v",
-			testCase.InputModelDeploymentID, testCase.InputModelStatus,
-			testCase.InputModelDeploymentFinishedFlag, testCase.InputModelIsDeploymentFinishedError,
-			testCase.InputModelError)
-		deploymentModel := new(mocks.DeploymentsModel)
+		t.Run(fmt.Sprintf("test case %d", testCaseNumber+1), func(t *testing.T) {
 
-		deploymentModel.On("AbortDeployment", testCase.InputModelDeploymentID).
-			Return(testCase.InputModelError)
+			deploymentModel := new(mocks.DeploymentsModel)
 
-		deploymentModel.On("IsDeploymentFinished", testCase.InputModelDeploymentID).
-			Return(testCase.InputModelDeploymentFinishedFlag, testCase.InputModelIsDeploymentFinishedError)
+			deploymentModel.On("AbortDeployment", testCase.InputModelDeploymentID).
+				Return(testCase.InputModelError)
 
-		router, err := rest.MakeRouter(
-			rest.Post("/r/:id",
-				NewDeploymentsController(deploymentModel,
-					new(view.DeploymentsView)).AbortDeployment))
-		assert.NoError(t, err)
+			deploymentModel.On("IsDeploymentFinished", testCase.InputModelDeploymentID).
+				Return(testCase.InputModelDeploymentFinishedFlag, testCase.InputModelIsDeploymentFinishedError)
 
-		api := makeApi(router)
+			router, err := rest.MakeRouter(
+				rest.Post("/r/:id",
+					NewDeploymentsController(deploymentModel,
+						new(view.DeploymentsView)).AbortDeployment))
+			assert.NoError(t, err)
 
-		req := test.MakeSimpleRequest("POST", "http://localhost/r/"+testCase.InputModelDeploymentID,
-			testCase.InputBodyObject)
-		req.Header.Add(requestid.RequestIdHeader, "test")
-		recorded := test.RunRequest(t, api.MakeHandler(), req)
+			api := makeApi(router)
 
-		h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+			req := test.MakeSimpleRequest("POST", "http://localhost/r/"+testCase.InputModelDeploymentID,
+				testCase.InputBodyObject)
+			req.Header.Add(requestid.RequestIdHeader, "test")
+			recorded := test.RunRequest(t, api.MakeHandler(), req)
+
+			h.CheckRecordedResponse(t, recorded, testCase.JSONResponseParams)
+		})
 	}
 }

--- a/resources/deployments/model/deployments.go
+++ b/resources/deployments/model/deployments.go
@@ -174,7 +174,7 @@ func (d *DeploymentsModel) GetDeploymentForDeviceWithCurrent(deviceID string,
 		return nil, nil
 	}
 
-	if installed.Artifact != "" && deployment.Image.ArtifactName == installed.Artifact {
+	if installed.Artifact != "" && deployment.Image.Name == installed.Artifact {
 		// pretend there is no deployment for this device, but update
 		// its status to already installed first
 
@@ -196,7 +196,7 @@ func (d *DeploymentsModel) GetDeploymentForDeviceWithCurrent(deviceID string,
 	instructions := &deployments.DeploymentInstructions{
 		ID: *deployment.DeploymentId,
 		Artifact: deployments.ArtifactDeploymentInstructions{
-			ArtifactName:          deployment.Image.ArtifactName,
+			ArtifactName:          deployment.Image.Name,
 			Source:                *link,
 			DeviceTypesCompatible: deployment.Image.DeviceTypesCompatible,
 		},

--- a/resources/images/controller/images.go
+++ b/resources/images/controller/images.go
@@ -214,6 +214,21 @@ func (s *SoftwareImagesController) EditImage(w rest.ResponseWriter, r *rest.Requ
 	s.view.RenderSuccessPut(w)
 }
 
+func (s SoftwareImagesController) getSoftwareImageMetaConstructorFromBody(r *rest.Request) (*images.SoftwareImageMetaConstructor, error) {
+
+	var constructor *images.SoftwareImageMetaConstructor
+
+	if err := r.DecodeJsonPayload(&constructor); err != nil {
+		return nil, err
+	}
+
+	if err := constructor.Validate(); err != nil {
+		return nil, err
+	}
+
+	return constructor, nil
+}
+
 // Multipart Image/Meta upload handler.
 // Request should be of type "multipart/form-data".
 // First part should contain Metadata file. This file should be of type "application/json".
@@ -266,12 +281,6 @@ func (s *SoftwareImagesController) parseMultipart(mr *multipart.Reader, maxMetaS
 			return nil, nil, errors.Wrap(err, "Request does not contain artifact")
 		}
 		switch p.FormName() {
-		case "name":
-			name, err := s.getFormFieldValue(p, maxMetaSize)
-			if err != nil {
-				return nil, nil, err
-			}
-			constructor.Name = *name
 		case "description":
 			desc, err := s.getFormFieldValue(p, maxMetaSize)
 			if err != nil {
@@ -297,19 +306,4 @@ func (s *SoftwareImagesController) getFormFieldValue(p *multipart.Part, maxMetaS
 
 	strValue := string(bytes)
 	return &strValue, nil
-}
-
-func (s SoftwareImagesController) getSoftwareImageMetaConstructorFromBody(r *rest.Request) (*images.SoftwareImageMetaConstructor, error) {
-
-	var constructor *images.SoftwareImageMetaConstructor
-
-	if err := r.DecodeJsonPayload(&constructor); err != nil {
-		return nil, err
-	}
-
-	if err := constructor.Validate(); err != nil {
-		return nil, err
-	}
-
-	return constructor, nil
 }

--- a/resources/images/image.go
+++ b/resources/images/image.go
@@ -22,9 +22,6 @@ import (
 
 // Informations provided by the user
 type SoftwareImageMetaConstructor struct {
-	// Application Name & Version
-	Name string `json:"name" bson:"name" valid:"length(1|4096),required"`
-
 	// Image description
 	Description string `json:"description,omitempty" valid:"length(1|4096),optional"`
 }
@@ -51,40 +48,10 @@ type ArtifactInfo struct {
 	Version uint `json:"version" valid:"required"`
 }
 
-// Type info structure
-type ArtifactUpdateTypeInfo struct {
-	Type string `json:"type" valid:"required"`
-}
-
-// Update file structure
-type UpdateFile struct {
-	// Image name
-	Name string `json:"name" valid:"required"`
-
-	// Image file checksum
-	Checksum string `json:"checksum" valid:"optional"`
-
-	// Image file signature
-	Signature string `json:"signature" valid:"optional"`
-
-	// Image size
-	Size int64 `json:"size" valid:"optional"`
-
-	// Date build
-	Date *time.Time `json:"date" valid:"optional"`
-}
-
-// Update structure
-type Update struct {
-	TypeInfo ArtifactUpdateTypeInfo `json:"type_info" valid:"required"`
-	Files    []UpdateFile           `json:"files"`
-	MetaData interface{}            `json:"meta_data" valid:"optional"` //TODO check this
-}
-
 // Information provided with YOCTO image
 type SoftwareImageMetaArtifactConstructor struct {
 	// artifact_name from artifact file
-	ArtifactName string `json:"artifact_name" bson:"artifact_name" valid:"length(1|4096),required"`
+	Name string `json:"name" bson:"name" valid:"length(1|4096),required"`
 
 	// Compatible device types for the application
 	DeviceTypesCompatible []string `json:"device_types_compatible" bson:"device_types_compatible" valid:"length(1|4096),required"`

--- a/resources/images/image_test.go
+++ b/resources/images/image_test.go
@@ -21,7 +21,7 @@ const validUUIDv4 = "d50eda0d-2cea-4de1-8d42-9cd3e7e8670d"
 func TestValidateEmptyImageMeta(t *testing.T) {
 	image := NewSoftwareImageMetaConstructor()
 
-	if err := image.Validate(); err == nil {
+	if err := image.Validate(); err != nil {
 		t.FailNow()
 	}
 }
@@ -36,9 +36,6 @@ func TestValidateEmptyImageMetaArtifact(t *testing.T) {
 
 func TestValidateCorrectImageMeta(t *testing.T) {
 	image := NewSoftwareImageMetaConstructor()
-	required := "required"
-
-	image.Name = required
 
 	if err := image.Validate(); err != nil {
 		t.FailNow()
@@ -49,7 +46,7 @@ func TestValidateCorrectImageMetaYocot(t *testing.T) {
 	image := NewSoftwareImageMetaArtifactConstructor()
 	required := "required"
 
-	image.ArtifactName = required
+	image.Name = required
 	image.DeviceTypesCompatible = []string{"required"}
 	image.Info = &ArtifactInfo{
 		Format:  required,
@@ -66,9 +63,8 @@ func TestValidateCorrectImage(t *testing.T) {
 	imageMeta := NewSoftwareImageMetaConstructor()
 	imageMetaArtifact := NewSoftwareImageMetaArtifactConstructor()
 
-	imageMetaArtifact.ArtifactName = required
+	imageMetaArtifact.Name = required
 	imageMetaArtifact.DeviceTypesCompatible = []string{"required"}
-	imageMeta.Name = required
 
 	image := NewSoftwareImage(validUUIDv4, imageMeta, imageMetaArtifact)
 

--- a/resources/images/model/images.go
+++ b/resources/images/model/images.go
@@ -143,7 +143,7 @@ func (i *ImagesModel) handleArtifact(
 	// artifact is considered to be unique if there is no artifact with the same name
 	// and supporing the same platform in the system
 	isArtifactUnique, err := i.imagesStorage.IsArtifactUnique(
-		metaArtifactConstructor.ArtifactName, metaArtifactConstructor.DeviceTypesCompatible)
+		metaArtifactConstructor.Name, metaArtifactConstructor.DeviceTypesCompatible)
 	if err != nil {
 		return "", errors.Wrap(err, "Fail to check if artifact is unique")
 	}
@@ -334,7 +334,7 @@ func getMetaFromArchive(
 	}
 	metaArtifact.Info = getArtifactInfo(aReader.GetInfo())
 	metaArtifact.DeviceTypesCompatible = aReader.GetCompatibleDevices()
-	metaArtifact.ArtifactName = aReader.GetArtifactName()
+	metaArtifact.Name = aReader.GetArtifactName()
 
 	for _, p := range data {
 		uFiles, err := getUpdateFiles(maxImageSize, p.GetUpdateFiles())

--- a/resources/images/model/images_test.go
+++ b/resources/images/model/images_test.go
@@ -95,12 +95,7 @@ func (fis *FakeImageStorage) IsArtifactUnique(artifactName string, deviceTypesCo
 }
 
 func createValidImageMeta() *images.SoftwareImageMetaConstructor {
-	imageMeta := images.NewSoftwareImageMetaConstructor()
-	required := "required"
-
-	imageMeta.Name = required
-
-	return imageMeta
+	return images.NewSoftwareImageMetaConstructor()
 }
 
 func createValidImageMetaArtifact() *images.SoftwareImageMetaArtifactConstructor {
@@ -108,7 +103,7 @@ func createValidImageMetaArtifact() *images.SoftwareImageMetaArtifactConstructor
 	required := "required"
 
 	imageMetaArtifact.DeviceTypesCompatible = []string{"required"}
-	imageMetaArtifact.ArtifactName = required
+	imageMetaArtifact.Name = required
 	imageMetaArtifact.Info = &images.ArtifactInfo{
 		Format:  required,
 		Version: 1,

--- a/resources/images/mongo/images.go
+++ b/resources/images/mongo/images.go
@@ -29,10 +29,9 @@ const (
 	// Keys are corelated to field names in SoftwareImageMeta
 	// and SoftwareImageMetaArtifact structures
 	// Need to be kept in sync with that structure filed names
-	StorageKeySoftwareImageDeviceTypes  = "meta_artifact.device_types_compatible"
-	StorageKeySoftwareImageArtifactName = "meta_artifact.artifact_name"
-	StorageKeySoftwareImageName         = "meta.name"
-	StorageKeySoftwareImageId           = "_id"
+	StorageKeySoftwareImageDeviceTypes = "meta_artifact.device_types_compatible"
+	StorageKeySoftwareImageName        = "meta_artifact.name"
+	StorageKeySoftwareImageId          = "_id"
 )
 
 // Indexes
@@ -209,7 +208,7 @@ func (i *SoftwareImagesStorage) IsArtifactUnique(artifactName string, deviceType
 	query := bson.M{
 		"$and": []bson.M{
 			bson.M{
-				StorageKeySoftwareImageArtifactName: artifactName,
+				StorageKeySoftwareImageName: artifactName,
 			},
 			bson.M{
 				StorageKeySoftwareImageDeviceTypes: bson.M{"$in": deviceTypesCompatible},

--- a/resources/images/mongo/images_test.go
+++ b/resources/images/mongo/images_test.go
@@ -15,11 +15,12 @@
 package mongo_test
 
 import (
+	"testing"
+
 	"github.com/mendersoftware/deployments/resources/images"
 	model "github.com/mendersoftware/deployments/resources/images/model"
 	. "github.com/mendersoftware/deployments/resources/images/mongo"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSoftwareImagesStorageImageByNameAndDeviceType(t *testing.T) {
@@ -32,12 +33,11 @@ func TestSoftwareImagesStorageImageByNameAndDeviceType(t *testing.T) {
 		&images.SoftwareImage{
 			Id: "1",
 			SoftwareImageMetaConstructor: images.SoftwareImageMetaConstructor{
-				Name:        "App1 v1.0",
 				Description: "description",
 			},
 
 			SoftwareImageMetaArtifactConstructor: images.SoftwareImageMetaArtifactConstructor{
-				ArtifactName:          "app1-v1.0",
+				Name: "App1 v1.0",
 				DeviceTypesCompatible: []string{"foo"},
 				Updates:               []images.Update{},
 			},
@@ -45,12 +45,11 @@ func TestSoftwareImagesStorageImageByNameAndDeviceType(t *testing.T) {
 		&images.SoftwareImage{
 			Id: "2",
 			SoftwareImageMetaConstructor: images.SoftwareImageMetaConstructor{
-				Name:        "App2 v0.1",
 				Description: "description",
 			},
 
 			SoftwareImageMetaArtifactConstructor: images.SoftwareImageMetaArtifactConstructor{
-				ArtifactName:          "app2-v0.1",
+				Name: "App2 v0.1",
 				DeviceTypesCompatible: []string{"bar", "baz"},
 				Updates:               []images.Update{},
 			},
@@ -124,30 +123,27 @@ func TestSoftwareImagesStorageImageByNameAndDeviceType(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		t.Logf("testing case %s", name)
-		var res []images.SoftwareImage
-		err := coll.Find(nil).All(&res)
-		t.Logf("DEBUG inserted imgs %v", res)
 
-		store := NewSoftwareImagesStorage(session)
+		// Run each test case as subtest
+		t.Run(name, func(t *testing.T) {
 
-		img, err := store.ImageByNameAndDeviceType(tc.InputImageName, tc.InputDevType)
-		t.Logf("DEBUG got img %v", img)
+			store := NewSoftwareImagesStorage(session)
+			img, err := store.ImageByNameAndDeviceType(tc.InputImageName, tc.InputDevType)
 
-		if tc.OutputError != nil {
-			assert.EqualError(t, err, tc.OutputError.Error())
-		} else {
-			assert.NoError(t, err)
-
-			if tc.OutputImage == nil {
-				assert.Nil(t, img)
+			if tc.OutputError != nil {
+				assert.EqualError(t, err, tc.OutputError.Error())
 			} else {
-				assert.NotNil(t, img)
-				assert.Equal(t, *tc.OutputImage, *img)
-			}
-		}
-	}
+				assert.NoError(t, err)
 
+				if tc.OutputImage == nil {
+					assert.Nil(t, img)
+				} else {
+					assert.NotNil(t, img)
+					assert.Equal(t, *tc.OutputImage, *img)
+				}
+			}
+		})
+	}
 }
 
 func TestIsArtifactUnique(t *testing.T) {
@@ -160,12 +156,11 @@ func TestIsArtifactUnique(t *testing.T) {
 		&images.SoftwareImage{
 			Id: "1",
 			SoftwareImageMetaConstructor: images.SoftwareImageMetaConstructor{
-				Name:        "App1 v1.0",
 				Description: "description",
 			},
 
 			SoftwareImageMetaArtifactConstructor: images.SoftwareImageMetaArtifactConstructor{
-				ArtifactName:          "app1-v1.0",
+				Name: "app1-v1.0",
 				DeviceTypesCompatible: []string{"foo", "bar"},
 				Updates:               []images.Update{},
 			},
@@ -216,22 +211,20 @@ func TestIsArtifactUnique(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		t.Logf("testing case %s", name)
-		var res []images.SoftwareImage
-		err := coll.Find(nil).All(&res)
-		t.Logf("DEBUG inserted imgs %v", res)
 
-		store := NewSoftwareImagesStorage(session)
+		// Run test cases as subtests
+		t.Run(name, func(t *testing.T) {
 
-		isUnique, err := store.IsArtifactUnique(tc.InputArtifactName, tc.InputDevTypes)
-		t.Logf("DEBUG is artifact unique: %v", isUnique)
+			store := NewSoftwareImagesStorage(session)
+			isUnique, err := store.IsArtifactUnique(tc.InputArtifactName, tc.InputDevTypes)
 
-		if tc.OutputError != nil {
-			assert.EqualError(t, err, tc.OutputError.Error())
-		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, tc.OutputIsUnique, isUnique)
-		}
+			if tc.OutputError != nil {
+				assert.EqualError(t, err, tc.OutputError.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.OutputIsUnique, isUnique)
+			}
+		})
 	}
 
 }

--- a/resources/images/update.go
+++ b/resources/images/update.go
@@ -1,0 +1,47 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package images
+
+import "time"
+
+// Type info structure
+type ArtifactUpdateTypeInfo struct {
+	Type string `json:"type" valid:"required"`
+}
+
+// Update file structure
+type UpdateFile struct {
+	// Image name
+	Name string `json:"name" valid:"required"`
+
+	// Image file checksum
+	Checksum string `json:"checksum" valid:"optional"`
+
+	// Image file signature
+	Signature string `json:"signature" valid:"optional"`
+
+	// Image size
+	Size int64 `json:"size" valid:"optional"`
+
+	// Date build
+	Date *time.Time `json:"date" valid:"optional"`
+}
+
+// Update structure
+type Update struct {
+	TypeInfo ArtifactUpdateTypeInfo `json:"type_info" valid:"required"`
+	Files    []UpdateFile           `json:"files"`
+	MetaData interface{}            `json:"meta_data" valid:"optional"` //TODO check this
+}


### PR DESCRIPTION
Remove user provided via from attribute 'name' of an artifact.
Cleanup unit tests.
Move update type to it's own file.
Rename artifact_name attribute of image into name.
Update API SPEC accrding to MEN-878

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>