### PR TITLE
introduce and use the middleware setting (defaults to prod)

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,6 +45,9 @@ const (
 
 	SettingGateway        = "mender-gateway"
 	SettingGatewayDefault = "localhost:9080"
+
+	SettingMiddleware        = "middleware"
+	SettingMiddlewareDefault = EnvProd
 )
 
 // ValidateAwsAuth validates configuration of SettingsAwsAuth section if provided.

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,16 @@
             # Defauls to: ":8080" which will listen on all avalable interfaces.
 listen: :8080
 
+    # HTTP Server middleware environment
+    # Available values:
+    #   dev
+    #       development environment
+    #   prod
+    #       production environment
+    #
+    # Defaults to: prod
+# middleware: dev
+
 
             # HTTPS configuration
             # To enable listening using HTTPS protocol please uncomment and configure following section.

--- a/middleware.go
+++ b/middleware.go
@@ -77,7 +77,12 @@ var DefaultProdStack = []rest.Middleware{
 }
 
 func SetupMiddleware(c config.ConfigReader, api *rest.Api) {
-	api.Use(DefaultDevStack...)
+	mwtype := c.GetString(SettingMiddleware)
+	if mwtype == EnvDev {
+		api.Use(DefaultDevStack...)
+	} else {
+		api.Use(DefaultProdStack...)
+	}
 
 	// Verifies the request Content-Type header if the content is non-null.
 	// For the POST /api/0.0.1/images request expected Content-Type is 'multipart/form-data'.


### PR DESCRIPTION
by default, `deployments` would spit out stack traces on panics - this was because the dev middleware stack was used by default (with `RecoverMiddleware` having `EnableResponseStackTrace: true`).

the dev/prod distinction was missing, so this PR introduces it (with `prod` as the default, i.e. no stack traces, just a generic "internal server error").

Issues: MEN-898