### PR TITLE
fix Deployment.GetStatus() 

### DIFF
--- a/resources/deployments/deployment.go
+++ b/resources/deployments/deployment.go
@@ -138,7 +138,13 @@ func (d *Deployment) IsInProgress() bool {
 		acount += d.Stats[s]
 	}
 
-	if acount != 0 {
+	if acount != 0 ||
+		(d.Stats[DeviceDeploymentStatusPending] > 0 &&
+			(d.Stats[DeviceDeploymentStatusAlreadyInst] > 0 ||
+				d.Stats[DeviceDeploymentStatusSuccess] > 0 ||
+				d.Stats[DeviceDeploymentStatusFailure] > 0 ||
+				d.Stats[DeviceDeploymentStatusNoArtifact] > 0 ||
+				d.Stats[DeviceDeploymentStatusAborted] > 0)) {
 		return true
 	}
 	return false
@@ -168,26 +174,31 @@ func (d *Deployment) IsFinished() bool {
 }
 
 func (d *Deployment) IsPending() bool {
-	if d.IsInProgress() {
-		return false
+	//pending > 0, evt else == 0
+	if d.Stats[DeviceDeploymentStatusPending] > 0 &&
+		d.Stats[DeviceDeploymentStatusDownloading] == 0 &&
+		d.Stats[DeviceDeploymentStatusInstalling] == 0 &&
+		d.Stats[DeviceDeploymentStatusRebooting] == 0 &&
+		d.Stats[DeviceDeploymentStatusSuccess] == 0 &&
+		d.Stats[DeviceDeploymentStatusAlreadyInst] == 0 &&
+		d.Stats[DeviceDeploymentStatusFailure] == 0 &&
+		d.Stats[DeviceDeploymentStatusNoArtifact] == 0 {
+
+		return true
 	}
 
-	if d.IsFinished() {
-		return false
-	}
-
-	return true
+	return false
 }
 
 func (d *Deployment) GetStatus() string {
 	if d.IsAborted() {
 		return "aborted"
-	} else if d.IsInProgress() {
-		return "inprogress"
+	} else if d.IsPending() {
+		return "pending"
 	} else if d.IsFinished() {
 		return "finished"
 	} else {
-		return "pending"
+		return "inprogress"
 	}
 }
 

--- a/resources/deployments/deployment.go
+++ b/resources/deployments/deployment.go
@@ -188,9 +188,7 @@ func (d *Deployment) IsPending() bool {
 }
 
 func (d *Deployment) GetStatus() string {
-	if d.IsAborted() {
-		return "aborted"
-	} else if d.IsPending() {
+	if d.IsPending() {
 		return "pending"
 	} else if d.IsFinished() {
 		return "finished"

--- a/resources/deployments/deployment.go
+++ b/resources/deployments/deployment.go
@@ -160,17 +160,14 @@ func (d *Deployment) IsAborted() bool {
 }
 
 func (d *Deployment) IsFinished() bool {
-	// check if there are downloading/rebooting/installing devices
-	if d.IsInProgress() {
-		return false
+	if d.Stats[DeviceDeploymentStatusPending] == 0 &&
+		d.Stats[DeviceDeploymentStatusDownloading] == 0 &&
+		d.Stats[DeviceDeploymentStatusInstalling] == 0 &&
+		d.Stats[DeviceDeploymentStatusRebooting] == 0 {
+		return true
 	}
 
-	// check if there are pending devices
-	if d.Stats[DeviceDeploymentStatusPending] != 0 {
-		return false
-	}
-
-	return true
+	return false
 }
 
 func (d *Deployment) IsPending() bool {

--- a/resources/deployments/deployment_external_test.go
+++ b/resources/deployments/deployment_external_test.go
@@ -331,6 +331,22 @@ func TestDeploymentGetStatus(t *testing.T) {
 		"Empty": {
 			OutputStatus: "finished",
 		},
+		//verify we count 'already-installed' towards 'inprogress'
+		"pending + already-installed": {
+			Stats: map[string]int{
+				DeviceDeploymentStatusPending:     1,
+				DeviceDeploymentStatusAlreadyInst: 1,
+			},
+			OutputStatus: "inprogress",
+		},
+		//verify we count 'already-installed' towards 'finished'
+		"already-installed + finished": {
+			Stats: map[string]int{
+				DeviceDeploymentStatusPending:     0,
+				DeviceDeploymentStatusAlreadyInst: 1,
+			},
+			OutputStatus: "finished",
+		},
 	}
 
 	for name, test := range tests {

--- a/resources/deployments/deployment_external_test.go
+++ b/resources/deployments/deployment_external_test.go
@@ -299,7 +299,7 @@ func TestDeploymentGetStatus(t *testing.T) {
 				DeviceDeploymentStatusFailure: 1,
 				DeviceDeploymentStatusAborted: 1,
 			},
-			OutputStatus: "aborted",
+			OutputStatus: "finished",
 		},
 		"Rebooting + NoArtifact": {
 			Stats: map[string]int{

--- a/resources/deployments/mongo/deployments.go
+++ b/resources/deployments/mongo/deployments.go
@@ -330,39 +330,16 @@ func buildStatusQuery(status deployments.StatusQuery) bson.M {
 			stq = bson.M{
 				"$and": []bson.M{
 					bson.M{
-						"$and": []bson.M{
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusDownloading): eq0,
-							},
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusInstalling): eq0,
-							},
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusRebooting): eq0,
-							},
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusPending): eq0,
-							},
-						},
+						buildStatusKey(deployments.DeviceDeploymentStatusDownloading): eq0,
 					},
 					bson.M{
-						"$or": []bson.M{
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusSuccess): gt0,
-							},
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusFailure): gt0,
-							},
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusNoArtifact): gt0,
-							},
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusAlreadyInst): gt0,
-							},
-							bson.M{
-								buildStatusKey(deployments.DeviceDeploymentStatusAborted): gt0,
-							},
-						},
+						buildStatusKey(deployments.DeviceDeploymentStatusInstalling): eq0,
+					},
+					bson.M{
+						buildStatusKey(deployments.DeviceDeploymentStatusRebooting): eq0,
+					},
+					bson.M{
+						buildStatusKey(deployments.DeviceDeploymentStatusPending): eq0,
 					},
 				},
 			}

--- a/resources/deployments/mongo/deployments.go
+++ b/resources/deployments/mongo/deployments.go
@@ -249,7 +249,8 @@ func buildStatusQuery(status deployments.StatusQuery) bson.M {
 	switch status {
 	case deployments.StatusQueryInProgress:
 		{
-			// downloading, installing or rebooting are non 0
+			// downloading, installing or rebooting are non 0, or
+			// already-installed/success/failure/noimage >0 and pending > 0
 			stq = bson.M{
 				"$or": []bson.M{
 					bson.M{
@@ -261,9 +262,33 @@ func buildStatusQuery(status deployments.StatusQuery) bson.M {
 					bson.M{
 						buildStatusKey(deployments.DeviceDeploymentStatusRebooting): gt0,
 					},
+					bson.M{
+						"$and": []bson.M{
+							bson.M{
+								buildStatusKey(deployments.DeviceDeploymentStatusPending): gt0,
+							},
+							bson.M{
+								"$or": []bson.M{
+									bson.M{
+										buildStatusKey(deployments.DeviceDeploymentStatusAlreadyInst): gt0,
+									},
+									bson.M{
+										buildStatusKey(deployments.DeviceDeploymentStatusSuccess): gt0,
+									},
+									bson.M{
+										buildStatusKey(deployments.DeviceDeploymentStatusFailure): gt0,
+									},
+									bson.M{
+										buildStatusKey(deployments.DeviceDeploymentStatusNoArtifact): gt0,
+									},
+								},
+							},
+						},
+					},
 				},
 			}
 		}
+
 	case deployments.StatusQueryPending:
 		{
 			// all status counters, except for pending, are 0

--- a/resources/deployments/mongo/deployments_external_test.go
+++ b/resources/deployments/mongo/deployments_external_test.go
@@ -783,6 +783,71 @@ func TestDeploymentStorageFindBy(t *testing.T) {
 				deployments.DeviceDeploymentStatusAborted: 1,
 			}),
 		},
+
+		//in progress deployment, with only pending and already-installed counters > 0
+		&deployments.Deployment{
+			DeploymentConstructor: &deployments.DeploymentConstructor{
+				Name:         StringToPointer("baz"),
+				ArtifactName: StringToPointer("asdf"),
+				Devices:      []string{"b532b01a-9313-404f-8d19-e7fcbe5cc347"},
+			},
+			Id: StringToPointer("12345678-0a41-401f-8f5e-582aba2a002d"),
+			Stats: newTestStats(deployments.Stats{
+				deployments.DeviceDeploymentStatusPending:     1,
+				deployments.DeviceDeploymentStatusAlreadyInst: 1,
+			}),
+		},
+		//in progress deployment, with only pending and success counters > 0
+		&deployments.Deployment{
+			DeploymentConstructor: &deployments.DeploymentConstructor{
+				Name:         StringToPointer("baz"),
+				ArtifactName: StringToPointer("asdf"),
+				Devices:      []string{"b532b01a-9313-404f-8d19-e7fcbe5cc347"},
+			},
+			Id: StringToPointer("22345678-0a41-401f-8f5e-582aba2a002d"),
+			Stats: newTestStats(deployments.Stats{
+				deployments.DeviceDeploymentStatusPending: 1,
+				deployments.DeviceDeploymentStatusSuccess: 1,
+			}),
+		},
+		//in progress deployment, with only pending and failure counters > 0
+		&deployments.Deployment{
+			DeploymentConstructor: &deployments.DeploymentConstructor{
+				Name:         StringToPointer("baz"),
+				ArtifactName: StringToPointer("asdf"),
+				Devices:      []string{"b532b01a-9313-404f-8d19-e7fcbe5cc347"},
+			},
+			Id: StringToPointer("32345678-0a41-401f-8f5e-582aba2a002d"),
+			Stats: newTestStats(deployments.Stats{
+				deployments.DeviceDeploymentStatusPending: 1,
+				deployments.DeviceDeploymentStatusFailure: 1,
+			}),
+		},
+		//in progress deployment, with only pending and noartifact counters > 0
+		&deployments.Deployment{
+			DeploymentConstructor: &deployments.DeploymentConstructor{
+				Name:         StringToPointer("baz"),
+				ArtifactName: StringToPointer("asdf"),
+				Devices:      []string{"b532b01a-9313-404f-8d19-e7fcbe5cc347"},
+			},
+			Id: StringToPointer("42345678-0a41-401f-8f5e-582aba2a002d"),
+			Stats: newTestStats(deployments.Stats{
+				deployments.DeviceDeploymentStatusPending:    1,
+				deployments.DeviceDeploymentStatusNoArtifact: 1,
+			}),
+		},
+		//finished deployment, with only already installed counter > 0
+		&deployments.Deployment{
+			DeploymentConstructor: &deployments.DeploymentConstructor{
+				Name:         StringToPointer("baz"),
+				ArtifactName: StringToPointer("asdf"),
+				Devices:      []string{"b532b01a-9313-404f-8d19-e7fcbe5cc347"},
+			},
+			Id: StringToPointer("52345678-0a41-401f-8f5e-582aba2a002d"),
+			Stats: newTestStats(deployments.Stats{
+				deployments.DeviceDeploymentStatusAlreadyInst: 1,
+			}),
+		},
 	}
 
 	testCases := []struct {
@@ -867,6 +932,10 @@ func TestDeploymentStorageFindBy(t *testing.T) {
 			OutputID: []string{
 				"3fe15222-0a41-401f-8f5e-582aba2a002d",
 				"3fe15222-1234-401f-8f5e-582aba2a002e",
+				"12345678-0a41-401f-8f5e-582aba2a002d",
+				"22345678-0a41-401f-8f5e-582aba2a002d",
+				"32345678-0a41-401f-8f5e-582aba2a002d",
+				"42345678-0a41-401f-8f5e-582aba2a002d",
 			},
 		},
 		{
@@ -888,6 +957,7 @@ func TestDeploymentStorageFindBy(t *testing.T) {
 				"3fe15222-0a41-401f-8f5e-582aba2a002c",
 				"44dd8822-eeb1-44db-a18e-f4f5acc43796",
 				"3fe15222-1234-401f-8f5e-582aba2a002a",
+				"52345678-0a41-401f-8f5e-582aba2a002d",
 			},
 		},
 		{
@@ -907,6 +977,11 @@ func TestDeploymentStorageFindBy(t *testing.T) {
 				"3fe15222-1234-401f-8f5e-582aba2a002f",
 				"44dd8822-eeb1-44db-a18e-f4f5acc43796",
 				"3fe15222-1234-401f-8f5e-582aba2a002a",
+				"12345678-0a41-401f-8f5e-582aba2a002d",
+				"22345678-0a41-401f-8f5e-582aba2a002d",
+				"32345678-0a41-401f-8f5e-582aba2a002d",
+				"42345678-0a41-401f-8f5e-582aba2a002d",
+				"52345678-0a41-401f-8f5e-582aba2a002d",
 			},
 		},
 	}


### PR DESCRIPTION
Issue: https://tracker.mender.io/browse/MEN-935

the crux of the issue is that the `already-installed` state is not included in our checks when calling `Get /deployments/:id` - see jira ticket for discussion.

solution: refactor and simplify the GetStatus() method to correctly (and more explicitly) handle all state combinations.

@mendersoftware/rndity @maciejmrowiec 