### PR TITLE
Mongo schema version

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -1,0 +1,44 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package main
+
+import (
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/pkg/errors"
+	"gopkg.in/mgo.v2"
+)
+
+const (
+	DbVersion = "0.0.1"
+	DbName    = "deployment_service"
+)
+
+func MigrateDb(version string, migrations []migrate.Migration, session *mgo.Session) error {
+	m := migrate.DummyMigrator{
+		Session: session,
+		Db:      DbName,
+	}
+
+	ver, err := migrate.NewVersion(version)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse service version")
+	}
+
+	err = m.Apply(ver, migrations)
+	if err != nil {
+		return errors.Wrap(err, "failed to apply migrations")
+	}
+
+	return nil
+}

--- a/routing.go
+++ b/routing.go
@@ -60,6 +60,11 @@ func NewRouter(c config.ConfigReader) (rest.App, error) {
 	}
 	dbSession.SetSafe(&mgo.Safe{})
 
+	err = MigrateDb(DbVersion, nil, dbSession)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to migrate db")
+	}
+
 	// Storage Layer
 	fileStorage, err := SetupS3(c)
 	if err != nil {

--- a/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/db.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/db.go
@@ -1,0 +1,66 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package migrate
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"gopkg.in/mgo.v2"
+)
+
+// this is a small internal data layer for the migration utils, may be shared by diff migrators
+const (
+	DbMigrationsColl = "migration_info"
+)
+
+type MigrationEntry struct {
+	Version   *Version  `bson:"version"`
+	Timestamp time.Time `bson:"timestamp"`
+}
+
+// GetMigrationInfo retrieves a list of migrations applied to the db.
+func GetMigrationInfo(sess *mgo.Session, db string) ([]MigrationEntry, error) {
+	s := sess.Copy()
+	defer s.Close()
+	c := s.DB(db).C(DbMigrationsColl)
+
+	var info []MigrationEntry
+
+	var err = c.Find(nil).All(&info)
+	if err != nil {
+		return nil, errors.Wrap(err, "db: failed to get migration info")
+	}
+
+	return info, nil
+}
+
+// UpdateMigrationInfo inserts a migration entry in the migration info collection.
+func UpdateMigrationInfo(version *Version, sess *mgo.Session, db string) error {
+	s := sess.Copy()
+	defer s.Close()
+	c := s.DB(db).C(DbMigrationsColl)
+
+	entry := MigrationEntry{
+		Version:   version,
+		Timestamp: time.Now(),
+	}
+
+	err := c.Insert(entry)
+	if err != nil {
+		return errors.Wrap(err, "db: failed to insert migration info")
+	}
+
+	return nil
+}

--- a/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/migration.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/migration.go
@@ -1,0 +1,20 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package migrate
+
+// Migration defines an incremental mongo migration step, with a concrete version.
+type Migration interface {
+	Up() error
+	Version() Version
+}

--- a/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/migrator.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/migrator.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package migrate
+
+// Migrator applies a list of migrations to bring the db up to target version.
+type Migrator interface {
+	Apply(version *Version, migrations []Migration) error
+}

--- a/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/migrator_dummy.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/migrator_dummy.go
@@ -1,0 +1,39 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package migrate
+
+import (
+	"gopkg.in/mgo.v2"
+)
+
+// MigratorDummy does not actually apply migrations, just inserts the
+// target version into the db to mark the initial/current state.
+type DummyMigrator struct {
+	Session *mgo.Session
+	Db      string
+}
+
+// Apply makes MigratorDummy implement the Migrator interface.
+func (m *DummyMigrator) Apply(version *Version, migrations []Migration) error {
+	applied, err := GetMigrationInfo(m.Session, m.Db)
+	if err != nil {
+		return err
+	}
+
+	if len(applied) == 0 {
+		return UpdateMigrationInfo(version, m.Session, m.Db)
+	}
+
+	return nil
+}

--- a/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/version.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/mongo/migrate/version.go
@@ -1,0 +1,44 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+type Version struct {
+	Major uint `bson:"major"`
+	Minor uint `bson:"minor"`
+	Patch uint `bson:"patch"`
+}
+
+func NewVersion(s string) (*Version, error) {
+	var maj, min, patch uint
+
+	n, err := fmt.Sscanf(s, "%d.%d.%d", &maj, &min, &patch)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse Version")
+	} else if n != 3 {
+		return nil, errors.New("invalid semver format")
+	}
+
+	return &Version{Major: maj, Minor: min, Patch: patch}, nil
+}
+
+func (v *Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -377,26 +377,32 @@
 		{
 			"checksumSHA1": "TBy4BC8vdb8QenUOK253xKqZ4r8=",
 			"path": "github.com/mendersoftware/go-lib-micro/accesslog",
-			"revision": "a3f1d56d8ed2d7f72292af96f05fb41cdf0f78bb",
-			"revisionTime": "2016-10-21T10:51:34Z"
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
 		},
 		{
 			"checksumSHA1": "ARd+lex1hH+zfIYpSf3TYQkEOOc=",
 			"path": "github.com/mendersoftware/go-lib-micro/log",
-			"revision": "a3f1d56d8ed2d7f72292af96f05fb41cdf0f78bb",
-			"revisionTime": "2016-10-21T10:51:34Z"
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
+		},
+		{
+			"checksumSHA1": "aCjBzigSqKZpBg3Dcci1MK3BFvg=",
+			"path": "github.com/mendersoftware/go-lib-micro/mongo/migrate",
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
 		},
 		{
 			"checksumSHA1": "Ehd9UaCA0vFt0OAa19CVlqKUZls=",
 			"path": "github.com/mendersoftware/go-lib-micro/requestid",
-			"revision": "a3f1d56d8ed2d7f72292af96f05fb41cdf0f78bb",
-			"revisionTime": "2016-10-21T10:51:34Z"
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
 		},
 		{
 			"checksumSHA1": "a4WDC5YQzenCbeZfIcFpCvr3Rpk=",
 			"path": "github.com/mendersoftware/go-lib-micro/requestlog",
-			"revision": "a3f1d56d8ed2d7f72292af96f05fb41cdf0f78bb",
-			"revisionTime": "2016-10-21T10:51:34Z"
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
 		},
 		{
 			"checksumSHA1": "P9Oklqj7hHq9jTTmelTzIXVcLcY=",


### PR DESCRIPTION
the 'migrate' method does not fit in either of the data layers, so it's
factored out to a separate function, and called in router where mgo session
is initialized.

Issues: MEN-889

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@maciejmrowiec @bboozzoo @kjaskiewiczz 