### PR TITLE
MEN-963: Update API versioning.

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -1,14 +1,14 @@
 swagger: '2.0'
 info:
   title: Deployments
-  version: '0.1'
+  version: '1'
   description: |
     An API for device firmware deployments. Intended for use by devices.
 
     Devices can get new updates and send information about current deployment status.
 
-host: 'docker.mender.io:8080'
-basePath: '/api/devices/0.1/deployments'
+host: 'docker.mender.io'
+basePath: '/api/devices/v1/deployments'
 schemes:
   - https
 

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -1,13 +1,13 @@
 swagger: '2.0'
 info:
   title: Deployments
-  version: '0.1'
+  version: '1'
   description: |
     An API for deployments and artifacts management.
     Intended for use by the web GUI.
 
-host: 'docker.mender.io:8080'
-basePath: '/api/management/0.1/deployments'
+host: 'docker.mender.io'
+basePath: '/api/management/v1/deployments'
 schemes:
   - https
 

--- a/middleware.go
+++ b/middleware.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ant0ine/go-json-rest/rest"
 	"github.com/mendersoftware/deployments/config"
 	"github.com/mendersoftware/go-lib-micro/accesslog"
+	"github.com/mendersoftware/go-lib-micro/customheader"
 	"github.com/mendersoftware/go-lib-micro/requestid"
 	"github.com/mendersoftware/go-lib-micro/requestlog"
 )
@@ -77,6 +78,12 @@ var DefaultProdStack = []rest.Middleware{
 }
 
 func SetupMiddleware(c config.ConfigReader, api *rest.Api) {
+
+	api.Use(&customheader.CustomHeaderMiddleware{
+		HeaderName:  "X-DEPLOYMENTS-VERSION",
+		HeaderValue: CreateVersionString(),
+	})
+
 	mwtype := c.GetString(SettingMiddleware)
 	if mwtype == EnvDev {
 		api.Use(DefaultDevStack...)

--- a/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware.go
@@ -1,0 +1,36 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package customheader
+
+import "github.com/ant0ine/go-json-rest/rest"
+
+// Add custom HTTP header to all server responses
+type CustomHeaderMiddleware struct {
+	HeaderName  string
+	HeaderValue string
+}
+
+// MiddlewareFunc makes CustomHeaderMiddleware implement the Middleware interface.
+func (c *CustomHeaderMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
+	return func(w rest.ResponseWriter, r *rest.Request) {
+
+		if len(c.HeaderName) > 0 {
+			w.Header().Add(c.HeaderName, c.HeaderValue)
+		}
+
+		// call the handler
+		h(w, r)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -261,12 +261,6 @@
 			"revisionTime": "2016-10-12T22:22:00Z"
 		},
 		{
-			"checksumSHA1": "H0s7iZn2nk/fq52QaaTeW+gSGgA=",
-			"path": "github.com/aws/aws-sdk-go/private/signer/v4",
-			"revision": "999b1591218c36d5050d1ba7266eba956e65965f",
-			"revisionTime": "2015-12-08T20:45:36Z"
-		},
-		{
 			"checksumSHA1": "01b4hmyUzoReoOyEDylDinWBSdA=",
 			"path": "github.com/aws/aws-sdk-go/private/util",
 			"revision": "afb8bf514d9344600dcb0f45e364d2b628b6c6d3",
@@ -379,6 +373,12 @@
 			"path": "github.com/mendersoftware/go-lib-micro/accesslog",
 			"revision": "a3f1d56d8ed2d7f72292af96f05fb41cdf0f78bb",
 			"revisionTime": "2016-10-21T10:51:34Z"
+		},
+		{
+			"checksumSHA1": "5PDgQnNLCVPQR537rMBdiAPm5aM=",
+			"path": "github.com/mendersoftware/go-lib-micro/customheader",
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
 		},
 		{
 			"checksumSHA1": "ARd+lex1hH+zfIYpSf3TYQkEOOc=",


### PR DESCRIPTION
Change public routing to v1, v2, v3 schema (v1).
Update documentation.
Remove port 8080 from swagger.
Add service version header returned by API

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>

@mendersoftware/rndity 