### PR TITLE
management_api: proper type for `size` in artifacts POST

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -360,7 +360,8 @@ paths:
           in: formData
           description: Size of the artifact file in megabytes.
           required: true
-          type: long
+          type: integer
+          format: long
         - name: description
           in: formData
           required: false


### PR DESCRIPTION
`long` is a format, not a type

@mendersoftware/rndity @maciejmrowiec @michaelatmender 