### PR TITLE
[1.0.x] Fix incorrect unit used in API documentation.

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -358,7 +358,7 @@ paths:
           description: Contains the JWT token issued by the User Administration and Authentication Service.
         - name: size
           in: formData
-          description: Size of the artifact file in megabytes.
+          description: Size of the artifact file in bytes.
           required: true
           type: long
         - name: description


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
(cherry picked from commit 2f6b46a785a8015b41861b32425871f30ed42d3a)