### PR TITLE
management_api: proper type for `size` in artifacts POST

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -360,7 +360,8 @@ paths:
           in: formData
           description: Size of the artifact file in bytes.
           required: true
-          type: long
+          type: integer
+          format: long
         - name: description
           in: formData
           required: false


### PR DESCRIPTION
`long` is a format, not a type

Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
(cherry picked from commit 5badd0d10d467efd9315218ff3a5139b68d3f190)

@eysteins @estenberg  This missing commit is causing the empty page