### PR TITLE
docs: http 404 -> 204 on DELETE /deployments/devices/{id}

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -346,8 +346,6 @@ paths:
       responses:
         204:
           description: Device was removed
-        404:
-          $ref: "#/responses/NotFoundError"
         500:
           description: Internal server error.
           schema:

--- a/resources/deployments/controller/controller_deployments.go
+++ b/resources/deployments/controller/controller_deployments.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ant0ine/go-json-rest/rest"
 	"github.com/asaskevich/govalidator"
 	"github.com/mendersoftware/deployments/resources/deployments"
+	"github.com/mendersoftware/deployments/resources/deployments/mongo"
 	"github.com/mendersoftware/deployments/utils/identity"
 	"github.com/mendersoftware/go-lib-micro/requestid"
 	"github.com/mendersoftware/go-lib-micro/requestlog"
@@ -403,9 +404,13 @@ func (d *DeploymentsController) DecommissionDevice(w rest.ResponseWriter, r *res
 	}
 
 	// Decommission deployments for devices and update deployment stats
-	if err := d.model.DecommissionDevice(id); err != nil {
-		d.view.RenderInternalError(w, r, err, l)
-	}
+	err := d.model.DecommissionDevice(id)
 
-	d.view.RenderEmptySuccessResponse(w)
+	switch err {
+	case nil, mongo.ErrStorageNotFound:
+		d.view.RenderEmptySuccessResponse(w)
+	default:
+		d.view.RenderInternalError(w, r, err, l)
+
+	}
 }

--- a/resources/deployments/mongo/deployments.go
+++ b/resources/deployments/mongo/deployments.go
@@ -35,6 +35,7 @@ const (
 var (
 	ErrDeploymentStorageInvalidDeployment = errors.New("Invalid deployment")
 	ErrStorageInvalidID                   = errors.New("Invalid id")
+	ErrStorageNotFound                    = errors.New("Not found")
 	ErrDeploymentStorageInvalidQuery      = errors.New("Invalid query")
 	ErrDeploymentStorageCannotExecQuery   = errors.New("Cannot execute query")
 	ErrStorageInvalidInput                = errors.New("invalid input")

--- a/resources/deployments/mongo/device_deployments.go
+++ b/resources/deployments/mongo/device_deployments.go
@@ -433,7 +433,7 @@ func (d *DeviceDeploymentsStorage) DecommissionDeviceDeployments(deviceId string
 	_, err := session.DB(DatabaseName).C(CollectionDevices).UpdateAll(selector, update)
 
 	if err == mgo.ErrNotFound {
-		return ErrStorageInvalidID
+		return ErrStorageNotFound
 	}
 
 	return err

--- a/resources/deployments/mongo/device_deployments.go
+++ b/resources/deployments/mongo/device_deployments.go
@@ -432,9 +432,5 @@ func (d *DeviceDeploymentsStorage) DecommissionDeviceDeployments(deviceId string
 
 	_, err := session.DB(DatabaseName).C(CollectionDevices).UpdateAll(selector, update)
 
-	if err == mgo.ErrNotFound {
-		return ErrStorageNotFound
-	}
-
 	return err
 }


### PR DESCRIPTION
Issues: MEN-1143

the purpose of this task was to use http 204 instead of 404 on DELETE /deployments/devices/{id}, however:

the controller never returns a http 404, the doc is wrong. all lower layer errors are wrapped in 500 'internal error'. it's not even clear what the intended meaning of the 404 was (i.e. 'what exactly was not found?').

there are a couple points where storage checks against mgo.ErrNotFound, but even those are IMO spurious - this error will not pop up here:
- DeviceDeployments.DecommissionDeviceDeployments
	- mgo.UpdateAll won't return an error according to docs (but Update would)
	- omitted in tests
- DeviceDeployments.FindAllDeploymentsForDeviceIDWithStatuses
	- Find().All() will return an empty list and no error (as opposed to FindId)
	- no unit test for this method
- DeviceDeploymentsStorage.AggregateDeviceDeploymentByStatus
	- Pipe().All() - the doc doesn't mention it returns any errors
	- omitted in tests
- DeploymentsStorage.UpdateStatsAndFinishDeployment
	- this is the only method which correctly expects mgo.ErrNotFound (UpdateId might return it)
	- however, this is also correctly propagated as 500 internal error - this operation is a part of a sequence, means something went out of sync in between

so IMO there's nothing left to do, and by accident we already have what we wanted. I'm only updating the doc and providing this detailed comment.

relevant code for quick reference:

- controller https://github.com/mendersoftware/deployments/blob/master/resources/deployments/controller/controller_deployments.go#L395
- ...delegates to model: https://github.com/mendersoftware/deployments/blob/master/resources/deployments/model/deployments.go#L368
- ...delegates to storage: 
- https://github.com/mendersoftware/deployments/blob/master/resources/deployments/mongo/device_deployments.go#L407 and
- https://github.com/mendersoftware/deployments/blob/master/resources/deployments/mongo/device_deployments.go#L152

@mendersoftware/rndity @maciejmrowiec 