### PR TITLE
Increase file upload request validity when pushing artifact to remote…

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -344,9 +344,11 @@ paths:
           $ref: "#/responses/InternalServerError"
 
     post:
-      summary: Create an artifact
+      summary: Upload mender artifact
       description: |
-        Creates artifact. Mulitpart request with meta and artifact.
+        Upload medner artifact. Mulitpart request with meta and artifact.
+        
+        Supports artifact (version v1)[https://github.com/mendersoftware/mender-artifact/blob/1.0.x/Documentation/artifact-format.md].
       consumes:
         - multipart/form-data
       parameters:

--- a/resources/images/s3/filestorage.go
+++ b/resources/images/s3/filestorage.go
@@ -177,7 +177,7 @@ func (s *SimpleStorageService) UploadArtifact(objectID string, size int64, artif
 	r, _ := s.client.PutObjectRequest(params)
 
 	// Presign request
-	uri, err := r.Presign(10 * time.Second)
+	uri, err := r.Presign(5 * time.Minute)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
… file storage.

Change presign validity from 10 seconds to 5 minutes to mitigate any time synchronization issues with file server.

Changelog: Title

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>
(cherry picked from commit 515155ea0691f4764124d2022b1d9d4d2a59ec61)