### PR TITLE
Misleading log entry removal.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2018 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -119,9 +119,6 @@ func cmdServer(args *cli.Context) error {
 		}
 	}
 	dbSession.Close()
-
-	l.Printf("Deployments Service, version %s starting up",
-		CreateVersionString())
 
 	err = RunServer(config.Config)
 	if err != nil {

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get -y -qq update && apt-get -qq -y install \
     python3-pytest python3-crypto python3-twisted python3-requests python3-yaml \
     python3-tz && \
     rm -rf /var/lib/apt/lists/* && \
-    pip3 install --quiet bravado==9.2.2 pymongo==3.6.1 pytest-ordering minio
+    pip3 install --quiet bravado==9.2.2 pymongo==3.6.1 pytest-ordering==0.5 minio
 
 RUN mkdir -p /testing
 ENTRYPOINT ["bash", "/testing/run.sh"]


### PR DESCRIPTION
Deployment service was logging "Deployments Service, version ... starting up"
info twice while starting.
