### PR TITLE
Changed the Dockerfile to handle the build of the deployments service.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
-FROM alpine:3.4
-
+FROM golang:1.11.4-alpine3.8 as builder
 RUN apk update && apk upgrade && \
-     apk add ca-certificates && \
-     rm -rf /var/cache/apk/*
+     apk add \
+     xz-dev \
+     musl-dev \
+     gcc
+RUN mkdir -p /go/src/github.com/mendersoftware/deployments
+COPY . /go/src/github.com/mendersoftware/deployments
+RUN cd /go/src/github.com/mendersoftware/deployments && env CGO_ENABLED=1 go build
 
-RUN mkdir /etc/deployments
-
+FROM alpine:3.6
+RUN apk update && apk upgrade && \
+     apk add --no-cache ca-certificates
+RUN mkdir -p /etc/deployments
 EXPOSE 8080
-
-COPY ./config.yaml /etc/deployments/
-
-ENTRYPOINT ["/entrypoint.sh", "--config", "/etc/deployments/config.yaml"]
-
+COPY ./config.yaml /etc/deployments
 COPY ./entrypoint.sh /entrypoint.sh
-COPY ./deployments /usr/bin/
+COPY --from=builder /go/src/github.com/mendersoftware/deployments/deployments /usr/bin
+CMD ["./entrypoint.sh"]  
+ENTRYPOINT ["/entrypoint.sh", "--config", "/etc/deployments/config.yaml"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,4 @@ if [ -n "$STORAGE_BACKEND_CERT" -a -e "$STORAGE_BACKEND_CERT" ]; then
     c_rehash $CERTS_DIR
 fi
 
-exec /usr/bin/deployments "$@"
+exec deployments "$@"


### PR DESCRIPTION
Changelog: The Dockerfile has changed so that all the source files are copied
into the container, then built using go install. This change was warranted by
the need for consistent builds across all services, and seemed to me the easiest
way to handle the cgo and musl dependencies consistently.

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>