### PR TITLE
Revert "Make sure the most specific error is wrapped, not the generic one."

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -218,7 +218,7 @@ func (d *Deployments) handleArtifact(ctx context.Context,
 	if err != nil {
 		pW.Close()
 		<-ch
-		return artifactID, errors.Wrap(err, ErrModelParsingArtifactFailed.Error())
+		return artifactID, errors.Wrap(ErrModelParsingArtifactFailed, err.Error())
 	}
 
 	// read the rest of the data,


### PR DESCRIPTION
This reverts commit 362569ba913454cf2646a11f73ea7ee0869e2d72.

We are doing that kind of wrapping because there is no easy way to unwrap the error.
API handler is looking at the error.Cause so it will be lost if we'll change wrapping here.