### PR TITLE
Removed dead assignment in DeploymentsPerTenantHandler()

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -812,7 +812,6 @@ func (d *DeploymentsApiHandlers) ProvisionTenantsHandler(w rest.ResponseWriter, 
 }
 
 func (d *DeploymentsApiHandlers) DeploymentsPerTenantHandler(w rest.ResponseWriter, r *rest.Request) {
-	ctx := r.Context()
 	l := requestlog.GetRequestLogger(r)
 	defer r.Body.Close()
 
@@ -829,7 +828,7 @@ func (d *DeploymentsApiHandlers) DeploymentsPerTenantHandler(w rest.ResponseWrit
 	}
 
 	ident := &identity.Identity{Tenant: tenantID}
-	ctx = identity.WithContext(r.Context(), ident)
+	ctx := identity.WithContext(r.Context(), ident)
 
 	if deps, err := d.app.LookupDeployment(ctx, query); err != nil {
 		rest_utils.RestErrWithLog(w, r, l, err, http.StatusBadRequest)


### PR DESCRIPTION
`ctx` was assigned, then reassigned. No behavior difference,
just making the function slightly more efficient / easier to read.

Reported by LGTM:
https://lgtm.com/rules/1510373626114/