### PR TITLE
Handle error from http.NewRequest() in GetDeviceInventory()

### DIFF
--- a/integration/inventory.go
+++ b/integration/inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/integration/inventory.go
+++ b/integration/inventory.go
@@ -66,6 +66,10 @@ func (api *MenderAPI) GetDeviceInventory(ctx context.Context, id DeviceID) (*Dev
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating get request for URL %s", url)
+	}
+
 	//propagate request id
 	reqId := ctx.Value(requestid.RequestIdHeader)
 	if reqId != nil {


### PR DESCRIPTION
According to sources for NewRequest:

https://golang.org/src/net/http/request.go?s=28198:28299#L828

It can return error in case URL is bad, context is nil, or
HTTP method is bad. I guess here, the most likely failure
would be a badly formed URL.

I assume that this "never happens", because it hasn't been a
problem, but it seems more correct to handle the error, just
in case.

Reported by LGTM:
https://lgtm.com/rules/1510373626114/