### PR TITLE
MEN-2019, MC-1144 cherry-pick to 1.8.x 

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,13 +117,11 @@ func cmdServer(args *cli.Context) error {
 			3)
 	}
 
-	if args.Bool("automigrate") {
-		err = mongo.Migrate(context.Background(), mongo.DbVersion, dbSession, true)
-		if err != nil {
-			return cli.NewExitError(
-				fmt.Sprintf("failed to run migrations: %v", err),
-				3)
-		}
+	err = mongo.Migrate(context.Background(), mongo.DbVersion, dbSession, args.Bool("automigrate"))
+	if err != nil {
+		return cli.NewExitError(
+			fmt.Sprintf("failed to run migrations: %v", err),
+			3)
 	}
 	dbSession.Close()
 

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -1283,16 +1283,6 @@ func (db *DataStoreMongo) DoEnsureAdditionalIndexing(dataBase string, session *m
 		return err
 	}
 
-	deploymentArtifactNameIndex := mgo.Index{
-		Key:        StorageIndexes,
-		Name:       IndexDeploymentArtifactNameStr,
-		Background: false,
-	}
-
-	err = session.DB(dataBase).
-		C(CollectionDeployments).
-		EnsureIndex(deploymentArtifactNameIndex)
-
 	return err
 }
 

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -41,8 +41,18 @@ const (
 
 // Indexes
 const (
-	IndexUniqeNameAndDeviceTypeStr = "uniqueNameAndDeviceTypeIndex"
-	IndexDeploymentArtifactNameStr = "deploymentArtifactNameIndex"
+	IndexUniqeNameAndDeviceTypeStr           = "uniqueNameAndDeviceTypeIndex"
+	IndexDeploymentArtifactNameStr           = "deploymentArtifactNameIndex"
+	IndexDeploymentDeviceStatusesStr         = "deviceIdWithStatusByCreated"
+	IndexDeploymentDeviceIdStatusStr         = "devicesIdWithStatus"
+	IndexDeploymentDeviceDeploymentIdStr     = "devicesDeploymentId"
+	IndexDeploymentStatusFinishedStr         = "deploymentStatusFinished"
+	IndexDeploymentStatusPendingStr          = "deploymentStatusPending"
+	IndexDeploymentCreatedStr                = "deploymentCreated"
+	IndexDeploymentDeviceStatusRebootingStr  = "deploymentsDeviceStatusRebooting"
+	IndexDeploymentDeviceStatusPendingStr    = "deploymentsDeviceStatusPending"
+	IndexDeploymentDeviceStatusInstallingStr = "deploymentsDeviceStatusInstalling"
+	IndexDeploymentDeviceStatusFinishedStr   = "deploymentsFinished"
 )
 
 var (
@@ -50,6 +60,37 @@ var (
 		"$text:" + StorageKeyDeploymentName,
 		"$text:" + StorageKeyDeploymentArtifactName,
 	}
+	StatusIndexes = []string{
+		StorageKeyDeviceDeploymentDeviceId,
+		StorageKeyDeviceDeploymentStatus,
+		StorageKeyDeploymentStatsCreated,
+	}
+	DeviceIDStatusIndexes         = []string{"deviceID", "status"} //IndexDeploymentDeviceIdStatusStr
+	DeploymentIdIndexes           = []string{"deploymentid"}       //IndexDeploymentDeviceDeploymentIdStr
+	DeploymentStatusFinishedIndex = []string{
+		"stats.downloading",
+		"stats.installing",
+		"stats.pending",
+		"stats.rebooting",
+		"-created",
+	} //IndexDeploymentStatusFinishedStr
+	DeploymentStatusPendingIndex = []string{
+		"stats.aborted",
+		"stats.already-installed",
+		"stats.decommissioned",
+		"stats.downloading",
+		"stats.failure",
+		"stats.installing",
+		"stats.noartifact",
+		"stats.rebooting",
+		"stats.success",
+		"-created",
+	} //IndexDeploymentStatusPendingStr
+	DeploymentCreatedIndex                = []string{"-created"}         //IndexDeploymentCreatedStr
+	DeploymentDeviceStatusRebootingIndex  = []string{"stats.rebooting"}  //IndexDeploymentDeviceStatusRebootingStr
+	DeploymentDeviceStatusPendingIndex    = []string{"stats.pending"}    //IndexDeploymentDeviceStatusPendingStr
+	DeploymentDeviceStatusInstallingIndex = []string{"stats.installing"} //IndexDeploymentDeviceStatusInstallingStr
+	DeploymentDeviceStatusFinishedIndex   = []string{"finished"}         //IndexDeploymentDeviceStatusFinishedStr
 )
 
 // Errors
@@ -94,6 +135,7 @@ const (
 	StorageKeyDeploymentName         = "deploymentconstructor.name"
 	StorageKeyDeploymentArtifactName = "deploymentconstructor.artifactname"
 	StorageKeyDeploymentStats        = "stats"
+	StorageKeyDeploymentStatsCreated = "created"
 	StorageKeyDeploymentFinished     = "finished"
 	StorageKeyDeploymentArtifacts    = "artifacts"
 )
@@ -551,7 +593,7 @@ func (db *DataStoreMongo) SaveDeviceDeploymentLog(ctx context.Context,
 	}
 
 	// update log messages
-	// if the deployment log is already present than messages will be overwritten
+	// if the deployment log is already present than messages will be overwritten
 	update := bson.M{
 		"$set": bson.M{
 			StorageKeyDeviceDeploymentLogMessages: log.Messages,
@@ -1068,6 +1110,192 @@ func (db *DataStoreMongo) DoEnsureIndexing(dataBase string, session *mgo.Session
 		EnsureIndex(deploymentArtifactNameIndex)
 }
 
+func (db *DataStoreMongo) DoEnsureAdditionalIndexing(dataBase string, session *mgo.Session) error {
+	deploymentDevicesStatusesIndex := mgo.Index{
+		Key:        StatusIndexes,
+		Name:       IndexDeploymentDeviceStatusesStr,
+		Background: false,
+	}
+
+	err := session.DB(dataBase).
+		C(CollectionDevices).
+		EnsureIndex(deploymentDevicesStatusesIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentDeviceIdStatusStr = "devicesIdWithStatus"
+	// deviceID:1
+	// status:1
+	deploymentDevicesStatusIdIndex := mgo.Index{
+		Key:        DeviceIDStatusIndexes,
+		Name:       IndexDeploymentDeviceIdStatusStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDevices).
+		EnsureIndex(deploymentDevicesStatusIdIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentDeviceDeploymentIdStr = "devicesDeploymentId"
+	// deploymentid:1
+	deploymentDeviceDeploymentIdIndex := mgo.Index{
+		Key:        DeploymentIdIndexes,
+		Name:       IndexDeploymentDeviceDeploymentIdStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDevices).
+		EnsureIndex(deploymentDeviceDeploymentIdIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentStatusFinishedStr = "deploymentStatusFinished"
+	// stats.downloading: 1
+	// stats.installing: 1
+	// stats.pending: 1
+	// stats.rebooting: 1
+	// created: -1
+	deploymentStatusFinishedIndex := mgo.Index{
+		Key:        DeploymentStatusFinishedIndex,
+		Name:       IndexDeploymentStatusFinishedStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDeployments).
+		EnsureIndex(deploymentStatusFinishedIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentStatusPendingStr = "deploymentStatusPending"
+	// stats.aborted: 1
+	// stats.already-installed: 1
+	// stats.decommissioned: 1
+	// stats.downloading: 1
+	// stats.failure: 1
+	// stats.installing: 1
+	// stats.noartifact: 1
+	// stats.rebooting: 1
+	// stats.success: 1
+	// created: -1
+	deploymentStatusPendingIndex := mgo.Index{
+		Key:        DeploymentStatusPendingIndex,
+		Name:       IndexDeploymentStatusPendingStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDeployments).
+		EnsureIndex(deploymentStatusPendingIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentCreatedStr = "deploymentCreated"
+	// created: -1
+	deploymentCreatedIndex := mgo.Index{
+		Key:        DeploymentCreatedIndex,
+		Name:       IndexDeploymentCreatedStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDeployments).
+		EnsureIndex(deploymentCreatedIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentDeviceStatusRebootingStr = "deploymentsDeviceStatusRebooting"
+	// stats.rebooting: 1
+	deploymentDeviceStatusRebootingIndex := mgo.Index{
+		Key:        DeploymentDeviceStatusRebootingIndex,
+		Name:       IndexDeploymentDeviceStatusRebootingStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDeployments).
+		EnsureIndex(deploymentDeviceStatusRebootingIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentDeviceStatusPendingStr = "deploymentsDeviceStatusPending"
+	// stats.pending: 1
+	deploymentDeviceStatusPendingIndex := mgo.Index{
+		Key:        DeploymentDeviceStatusPendingIndex,
+		Name:       IndexDeploymentDeviceStatusPendingStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDeployments).
+		EnsureIndex(deploymentDeviceStatusPendingIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentDeviceStatusInstallingStr = "deploymentsDeviceStatusInstalling"
+	// stats.installing: 1
+	deploymentDeviceStatusInstallingIndex := mgo.Index{
+		Key:        DeploymentDeviceStatusInstallingIndex,
+		Name:       IndexDeploymentDeviceStatusInstallingStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDeployments).
+		EnsureIndex(deploymentDeviceStatusInstallingIndex)
+
+	if err != nil {
+		return err
+	}
+
+	// IndexDeploymentDeviceStatusFinishedStr = "deploymentsFinished"
+	// finished: 1
+	deploymentDeviceStatusFinishedIndex := mgo.Index{
+		Key:        DeploymentDeviceStatusFinishedIndex,
+		Name:       IndexDeploymentDeviceStatusFinishedStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDeployments).
+		EnsureIndex(deploymentDeviceStatusFinishedIndex)
+
+	if err != nil {
+		return err
+	}
+
+	deploymentArtifactNameIndex := mgo.Index{
+		Key:        StorageIndexes,
+		Name:       IndexDeploymentArtifactNameStr,
+		Background: false,
+	}
+
+	err = session.DB(dataBase).
+		C(CollectionDeployments).
+		EnsureIndex(deploymentArtifactNameIndex)
+
+	return err
+}
+
 // return true if required indexing was set up
 func (db *DataStoreMongo) hasIndexing(ctx context.Context, session *mgo.Session) bool {
 	idxs, err := session.DB(mstore.DbFromContext(ctx, DatabaseName)).
@@ -1090,6 +1318,7 @@ func (db *DataStoreMongo) hasIndexing(ctx context.Context, session *mgo.Session)
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -1173,7 +1402,7 @@ func (db *DataStoreMongo) FindUnfinishedByID(ctx context.Context,
 
 	var deployment *model.Deployment
 	filter := bson.M{
-		"_id": id,
+		"_id":                        id,
 		StorageKeyDeploymentFinished: nil,
 	}
 	if err := session.DB(mstore.DbFromContext(ctx, DatabaseName)).

--- a/store/mongo/migration_1_2_2.go
+++ b/store/mongo/migration_1_2_2.go
@@ -1,0 +1,82 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"strings"
+
+	"github.com/globalsign/mgo"
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+)
+
+type migration_1_2_2 struct {
+	session *mgo.Session
+	db      string
+}
+
+// Up drops index with len(name) > 127 chars in the 'deployments' collection
+func (m *migration_1_2_2) Up(from migrate.Version) error {
+	s := m.session.Copy()
+	defer s.Close()
+
+	indicesArrays := [][]string{
+		StatusIndexes,
+		DeviceIDStatusIndexes,
+		DeploymentIdIndexes,
+	}
+	for _, index := range indicesArrays {
+		// DropIndex will use the same rules for exploding the index name
+		// as EnsureIndexKey previously used to create the 'long' index
+		err := s.DB(m.db).
+			C(CollectionDevices).
+			DropIndex(index...)
+
+		// 'ns not found' simply means the idx doesn't exist
+		// DropIndex is just not idempotent, so force it
+		if err != nil && err.Error() != "ns not found" && !strings.HasPrefix(err.Error(), "index not found with name") {
+			return err
+		}
+	}
+
+	indicesArrays = [][]string{
+		DeploymentStatusFinishedIndex,
+		DeploymentStatusPendingIndex,
+		DeploymentCreatedIndex,
+		DeploymentDeviceStatusRebootingIndex,
+		DeploymentDeviceStatusPendingIndex,
+		DeploymentDeviceStatusInstallingIndex,
+		DeploymentDeviceStatusFinishedIndex,
+	}
+	for _, index := range indicesArrays {
+		// DropIndex will use the same rules for exploding the index name
+		// as EnsureIndexKey previously used to create the 'long' index
+		err := s.DB(m.db).
+			C(CollectionDeployments).
+			DropIndex(index...)
+
+		// 'ns not found' simply means the idx doesn't exist
+		// DropIndex is just not idempotent, so force it
+		if err != nil && err.Error() != "ns not found" && !strings.HasPrefix(err.Error(), "index not found with name") {
+			return err
+		}
+	}
+
+	// create the 'short' index
+	storage := NewDataStoreMongoWithSession(m.session)
+	return storage.DoEnsureAdditionalIndexing(m.db, m.session)
+}
+
+func (m *migration_1_2_2) Version() migrate.Version {
+	return migrate.MakeVersion(1, 2, 2)
+}

--- a/store/mongo/migration_1_2_2_test.go
+++ b/store/mongo/migration_1_2_2_test.go
@@ -1,0 +1,136 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mendersoftware/deployments/model"
+)
+
+func TestMigration_1_2_2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestMigration_1_2_2 in short mode.")
+	}
+
+	testCases := map[string]struct {
+		// ST or MT naming convention
+		db    string
+		dbVer string
+
+		// non-empty deployments also means the index is already present
+		// must be nil for MT databases - the index name issue implies no deployments were created ever
+		deployments []*model.Deployment
+
+		err error
+	}{
+		"ST, no index, 0.0.0": {
+			db:          "deployments_service",
+			dbVer:       "",
+			deployments: nil,
+		},
+		"ST, no index, 0.0.1": {
+			db:          "deployments_service",
+			dbVer:       "0.0.1",
+			deployments: nil,
+		},
+		"ST, with index, 0.0.1": {
+			db:    "deployments_service",
+			dbVer: "0.0.1",
+			deployments: []*model.Deployment{
+				makeDeployment(t, "one", "artifact1"),
+				makeDeployment(t, "two", "artifact2"),
+			},
+		},
+		"MT, no index, 0.0.0": {
+			db:          "deployments_service-59afdb71c704db002a86ad95",
+			dbVer:       "",
+			deployments: nil,
+		},
+		"MT, no index, 0.0.1": {
+			db:          "deployments_service-59afdb71c704db002a86ad95",
+			dbVer:       "0.0.1",
+			deployments: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Logf("test case: %s", name)
+
+		db.Wipe()
+		s := db.Session()
+
+		// setup
+		// setup existing migrations
+		if tc.dbVer != "" {
+			ver, err := migrate.NewVersion(tc.dbVer)
+			assert.NoError(t, err)
+			migrate.UpdateMigrationInfo(*ver, s, tc.db)
+		}
+
+		// setup existing deployments
+		for _, d := range tc.deployments {
+			err := insertDeployment(d, s, tc.db)
+			assert.NoError(t, err)
+		}
+
+		migrations := []migrate.Migration{
+			&migration_1_2_1{
+				session: s,
+				db:      tc.db,
+			},
+			&migration_1_2_2{
+				session: s,
+				db:      tc.db,
+			},
+		}
+
+		m := migrate.SimpleMigrator{
+			Session:     s,
+			Db:          tc.db,
+			Automigrate: true,
+		}
+
+		//verify
+		// for DBs with data - just in case verify the old/long index was created
+		if tc.deployments != nil {
+			idxs, err := s.DB(tc.db).C(CollectionDeployments).Indexes()
+			assert.NoError(t, err)
+			hasOld := hasIndex(OldIndexName, idxs)
+			assert.True(t, hasOld)
+		}
+
+		err := m.Apply(context.Background(), migrate.MakeVersion(1, 2, 2), migrations)
+		assert.NoError(t, err)
+
+		// verify old index dropped
+		idxs, err := s.DB(tc.db).C(CollectionDeployments).Indexes()
+		assert.NoError(t, err)
+		hasOld := hasIndex(OldIndexName, idxs)
+		assert.False(t, hasOld)
+
+		// verify new index present - only if deployment inserted
+		if tc.deployments != nil {
+			hasNew := hasIndex(IndexDeploymentArtifactNameStr, idxs)
+			assert.NoError(t, err)
+			assert.True(t, hasNew)
+		}
+
+		s.Close()
+	}
+}

--- a/store/mongo/migrations.go
+++ b/store/mongo/migrations.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	DbVersion = "1.2.1"
+	DbVersion = "1.2.2"
 	DbName    = "deployment_service"
 )
 
@@ -82,6 +82,10 @@ func MigrateSingle(ctx context.Context,
 
 	migrations := []migrate.Migration{
 		&migration_1_2_1{
+			session: session,
+			db:      db,
+		},
+		&migration_1_2_2{
 			session: session,
 			db:      db,
 		},


### PR DESCRIPTION
MEN-2019 index deployments database
MC-1144 run migrations on startup like other services do

(cherry picked from commit 7145378db7380c01f38ae4ae8471fb74afb5fd2c)
(cherry picked from commit cacf81ba742f43e78f32df8b2edbae776b8f2b0e)
(cherry picked from commit 326c66a1679ac194d0e22ef098b38e07ccc890aa)
