### PR TITLE
Fix : Device Count showing as 0 in GET Deployment by ID API

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -570,6 +570,12 @@ func (d *Deployments) GetDeployment(ctx context.Context,
 	if err != nil {
 		return nil, errors.Wrap(err, "Searching for deployment by ID")
 	}
+	if deviceCount, err := d.db.DeviceCountByDeployment(ctx,
+		*deployment.Id); err != nil {
+		return nil, errors.Wrap(err, "counting device deployment")
+	} else {
+		deployment.DeviceCount = deviceCount
+	}
 
 	return deployment, nil
 }


### PR DESCRIPTION
**Issue :** The Device Count was always returning 0 whenever GET deployment by ID API was being called (GET /deployments/{id})

**RCA :** This was because the DeviceCount API wasn't being called post getting the deployment to fill up the DeviceCount value in the deployment struct

**Fix :** Added the DeviceCount API in the GetDeployment() function to fill in DeviceCOunt value in the deployment struct.