### PR TITLE
s3/filestorage: handle *all* errors from minio init

### DIFF
--- a/s3/filestorage.go
+++ b/s3/filestorage.go
@@ -95,6 +95,8 @@ func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri strin
 			if awsErr.Code() != ErrCodeBucketAlreadyOwnedByYou {
 				return nil, err
 			}
+		} else {
+			return nil, err
 		}
 	}
 
@@ -124,6 +126,8 @@ func NewSimpleStorageServiceDefaults(bucket, region string) (*SimpleStorageServi
 			if awsErr.Code() != ErrCodeBucketAlreadyOwnedByYou {
 				return nil, err
 			}
+		} else {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
only aws errors were handled, generic ones (connection errors?)
slipped through. as a result, deployments didn't even notice
minio is not there yet (or already dead).

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>

---
WRT integration failures - `deployments` didn't correctly init, and didn't detect minio connection errors. before adding smoke tests and monitoring of minio, let's merge this. it will help make clear if minio is the issue.