### PR TITLE
Timeout for the CreateBucket call to minio (or S3)

### DIFF
--- a/s3/filestorage.go
+++ b/s3/filestorage.go
@@ -89,12 +89,21 @@ func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri strin
 		Bucket: aws.String(bucket), // Required
 	}
 
-	_, err := client.CreateBucket(cparams)
+	ctx := context.Background()
+
+	// timeout set to 5 seconds
+	var cancelFn func()
+	ctxWithTimeout, cancelFn := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelFn()
+
+	_, err := client.CreateBucketWithContext(ctxWithTimeout, cparams)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() != ErrCodeBucketAlreadyOwnedByYou {
 				return nil, err
 			}
+		} else {
+			return nil, err
 		}
 	}
 
@@ -118,12 +127,21 @@ func NewSimpleStorageServiceDefaults(bucket, region string) (*SimpleStorageServi
 		Bucket: aws.String(bucket), // Required
 	}
 
-	_, err := client.CreateBucket(cparams)
+	ctx := context.Background()
+
+	// timeout set to 5 seconds
+	var cancelFn func()
+	ctxWithTimeout, cancelFn := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelFn()
+
+	_, err := client.CreateBucketWithContext(ctxWithTimeout, cparams)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() != ErrCodeBucketAlreadyOwnedByYou {
 				return nil, err
 			}
+		} else {
+			return nil, err
 		}
 	}
 

--- a/tests/docker-compose-acceptance.mt.yml
+++ b/tests/docker-compose-acceptance.mt.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     acceptance:
         image: testing

--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     acceptance:
         image: testing

--- a/tests/docker-compose-integration.yml
+++ b/tests/docker-compose-integration.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     mender-deployments:
             # built/tagged locally and only used for testing


### PR DESCRIPTION
The deployments service creates the S3 bucket at startup time: both
NewSimpleStorageServiceStatic and NewSimpleStorageServiceDefaults call
`client.CreateBucket` to initialize the bucket.

In case of error, the previous implementation returned `nil` and this caused
the process to exit with exit code `4`.

This commit applies a timeout (using `context.WithTimeout`) set to 5 seconds in
order to avoid the deployments service to hang and wait an indefinite amount of
time before retrying the command.

Changelog: title
Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>