### PR TITLE
Update docker-compose version to 2.1 for acceptance tests

### DIFF
--- a/tests/docker-compose-acceptance.mt.yml
+++ b/tests/docker-compose-acceptance.mt.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     acceptance:
         image: testing

--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     acceptance:
         image: testing

--- a/tests/docker-compose-integration.yml
+++ b/tests/docker-compose-integration.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     mender-deployments:
             # built/tagged locally and only used for testing


### PR DESCRIPTION
Update docker-compose version to 2.1 for acceptance tests to comply with the rest of the integration compose files.