### PR TITLE
tests: don't cleanup 'config' db when doing mongo cleanup

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -573,11 +573,10 @@ func (db *DataStoreMongo) InsertImage(ctx context.Context, image *model.Software
 		return err
 	}
 
-	res, err := collImg.InsertOne(ctx, image)
+	_, err := collImg.InsertOne(ctx, image)
 	if err != nil {
 		return err
 	}
-	image.Id = res.InsertedID.(string)
 
 	return nil
 }

--- a/tests/common.py
+++ b/tests/common.py
@@ -197,7 +197,7 @@ def clean_minio():
 
 def mongo_cleanup(mongo):
     dbs = mongo.database_names()
-    dbs = [d for d in dbs if d not in ['local', 'admin']]
+    dbs = [d for d in dbs if d not in ['local', 'admin', 'config']]
     for d in dbs:
         mongo.drop_database(d)
 


### PR DESCRIPTION
reason:

pymongo.errors.OperationFailure: Direct writes against
config.transactions cannot be performed using a transaction or on a
session.

introduced in 3.6 apparently - sessions are used by default, and
'config' is untouchable on a session.

https://jira.mongodb.org/browse/SERVER-35244