### PR TITLE
Refactor NewImage and NewImageForTenantHandler

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ test:acceptance_tests:
   script:
     - apk add git bash
     - export SHARED_PATH="$(dirname ${CI_PROJECT_DIR})"
-    - git clone https://github.com/mendersoftware/integration.git ${SHARED_PATH}/mender-integration
+    - git clone --depth=1 https://github.com/mendersoftware/integration.git ${SHARED_PATH}/mender-integration
     - mkdir -p ${SHARED_PATH}/tests
     - mv ${SHARED_PATH}/mender-integration/extra/travis-testing/* docs/* deployments mender-artifact tests/* ${SHARED_PATH}/tests
     - docker load -i acceptance_testing_image.tar

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 
-RUN pip3 install --quiet bravado==9.2.2 pymongo==3.6.1 pytest-ordering==0.5 minio crypto pytest==3.10.1 twisted requests pyyaml tz
+RUN pip3 install --quiet bravado==9.2.2 pymongo==3.6.1 pytest-ordering==0.5 minio==5.0.6 crypto pytest==3.10.1 twisted requests pyyaml tz
 
 RUN ln -s /lib64/ld-linux-x86-64.so.2 /lib/libc.musl-x86_64.so.1
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -192,7 +192,7 @@ def clean_db(mongo):
 def clean_minio():
     m = MinioClient()
 
-    for obj in m.list_objects("mender-artifact-storage"):
+    for obj in m.list_objects("mender-artifact-storage", recursive=True):
         m.remove_object("mender-artifact-storage", obj.object_name)
 
 def mongo_cleanup(mongo):

--- a/tests/tests/test_api_internal.py
+++ b/tests/tests/test_api_internal.py
@@ -12,9 +12,17 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-from common import api_client_int, mongo, clean_db
+
 import bravado
 import pytest
+import requests
+
+from uuid import uuid4
+
+from bson.objectid import ObjectId
+from common import api_client_int, artifact_from_data, mongo, clean_db, clean_minio
+from client import SimpleArtifactsClient, ArtifactsClientError
+
 
 class TestInternalApiTenantCreate:
     def test_create_ok(self, api_client_int, clean_db):
@@ -37,3 +45,55 @@ class TestInternalApiTenantCreate:
             _, r = api_client_int.create_tenant('')
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 400
+
+    @pytest.mark.usefixtures("clean_minio")
+    def test_artifacts_valid(self, api_client_int, mongo):
+        artifact_name = str(uuid4())
+        description = 'description for foo ' + artifact_name
+        device_type = 'project-' + str(uuid4())
+        data = b'foo_bar'
+
+        tenant_id = str(ObjectId())
+        _, r = api_client_int.create_tenant(tenant_id)
+        assert r.status_code == 201
+
+        # generate artifact
+        with artifact_from_data(name=artifact_name, data=data, devicetype=device_type) as art:
+            artifacts_client = SimpleArtifactsClient()
+
+            artifacts_client.log.info("uploading artifact")
+            artid = api_client_int.add_artifact(tenant_id, description, art.size, art)
+            assert artid is not None
+
+            # verify the artifact has been stored correctly in mongodb
+            artifact = mongo['deployment_service-{}'.format(tenant_id)].images.find_one({'_id': artid})
+            assert artifact is not None
+            #
+            assert artifact['_id'] == artid
+            assert artifact['meta_artifact']['name'] == artifact_name
+            assert artifact['meta']['description'] == description
+            assert artifact['size'] == int(art.size)
+            assert device_type in artifact['meta_artifact']['device_types_compatible']
+            assert len(artifact['meta_artifact']['updates']) == 1
+            update = artifact['meta_artifact']['updates'][0]
+            assert len(update['files']) == 1
+            uf = update['files'][0]
+            assert uf['size'] == len(data)
+            assert uf['checksum']
+
+    @pytest.mark.usefixtures("clean_minio")
+    def test_artifacts_fails_invalid_size(self, api_client_int):
+        artifact_name = str(uuid4())
+        description = 'description for foo ' + artifact_name
+        device_type = 'project-' + str(uuid4())
+        data = b'foo_bar'
+
+        tenant_id = str(ObjectId())
+
+        # generate artifact
+        with artifact_from_data(name=artifact_name, data=data, devicetype=device_type) as art:
+            artifacts_client = SimpleArtifactsClient()
+
+            artifacts_client.log.info("uploading artifact")
+            with pytest.raises(ArtifactsClientError):
+                api_client_int.add_artifact(tenant_id, description, 0, art)


### PR DESCRIPTION
NewImage and NewImageForTenantHandler overlap: the first is the
management API which requires the user to be authenticated via JWT
token, the latter is the internal end-point used to upload an artifact
for a given tenant without authentication.

Their implementations overlap, thus we refactor the functions to share
the common part.

changelog: none
Signed-off-by: Fabio Tranchitella fabio@tranchitella.eu