### PR TITLE
Set GIT_DEPTH variable to 0 in gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ cache:
 variables:
   DOCKER_HOST: tcp://docker:2375/
   DOCKER_DRIVER: overlay2
+  GIT_DEPTH: 0
 
 services:
   - docker:dind


### PR DESCRIPTION
We experienced gitlab pipeline failures due to shallow clones of the git
repository. We set the GIT_DEPTH variable to 0 to explicitly instruct
the GitLab Runners to perform a full clone.

changelog: none
Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>