### PR TITLE
Remove the size parameter from /artifacts/generate end-point

### DIFF
--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -171,7 +171,7 @@ paths:
       summary: Upload mender artifact
       description: |
         Upload mender artifact to a specific tenant. Multipart request with meta and artifact.
-        Supports artifact (versions v1, v2)[https://docs.mender.io/development/architecture/mender-artifacts#versions].
+        Supports artifact (versions v1, v2, and v3)[https://docs.mender.io/development/architecture/mender-artifacts#versions].
       consumes:
         - multipart/form-data
       parameters:

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -189,7 +189,7 @@ paths:
         - name: size
           in: formData
           description: Size of the artifact file in bytes.
-          required: true
+          required: false
           type: integer
           format: long
         - name: description

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -501,7 +501,7 @@ paths:
         - name: size
           in: formData
           description: Size of the artifact file in bytes.
-          required: true
+          required: false
           type: integer
           format: long
         - name: description
@@ -552,12 +552,6 @@ paths:
           description: Description of the artifact to generate.
           required: false
           type: string
-        - name: size
-          in: formData
-          description: Size of the file in bytes.
-          required: true
-          type: integer
-          format: long
         - name: device_types_compatible
           in: formData
           description: An array of compatible device types.

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -102,8 +102,8 @@ class ArtifactsClient(SwaggerApiClient):
         """
         # prepare upload data for multipart/form-data
         files = ArtifactsClient.make_upload_meta({
-            'description': description,
-            'size': str(size),
+            'description': (None, description),
+            'size': (None, str(size)),
             'artifact': ('firmware', data, 'application/octet-stream', {}),
         })
         rsp = requests.post(self.make_api_url('/artifacts'), files=files, verify=False)
@@ -121,7 +121,7 @@ class ArtifactsClient(SwaggerApiClient):
 
     @staticmethod
     def make_generate_meta(meta):
-        order = ['name', 'description', 'size', 'device_types_compatible', 'type', 'args', 'file']
+        order = ['name', 'description', 'device_types_compatible', 'type', 'args', 'file']
 
         upload_meta = OrderedDict()
         for entry in order:
@@ -129,7 +129,7 @@ class ArtifactsClient(SwaggerApiClient):
                 upload_meta[entry] = meta[entry]
         return upload_meta
 
-    def generate_artifact(self, name='', description='', size=0, device_types_compatible='', type='', args='', data=None):
+    def generate_artifact(self, name='', description='', device_types_compatible='', type='', args='', data=None):
         """Generate a new artifact with provided upload data.
         Data must be a file like object.
 
@@ -138,12 +138,11 @@ class ArtifactsClient(SwaggerApiClient):
         """
         # prepare upload data for multipart/form-data
         files = ArtifactsClient.make_generate_meta({
-            'name': name,
-            'description': description,
-            'size': str(size),
-            'device_types_compatible': device_types_compatible,
-            'type': type,
-            'args': args,
+            'name': (None, name),
+            'description': (None, description),
+            'device_types_compatible': (None, device_types_compatible),
+            'type': (None, type),
+            'args': (None, args),
             'file': ('firmware', data, 'application/octet-stream', {}),
         })
         rsp = requests.post(self.make_api_url('/artifacts/generate'), files=files, verify=False)
@@ -337,8 +336,8 @@ class InternalApiClient(SwaggerApiClient):
         """
         # prepare upload data for multipart/form-data
         files = ArtifactsClient.make_upload_meta({
-            'description': description,
-            'size': str(size),
+            'description': (None, description),
+            'size': (None, str(size)),
             'artifact': ('firmware', data, 'application/octet-stream', {}),
         })
         url = self.make_api_url('/tenants/{}/artifacts'.format(tenant_id))

--- a/tests/tests/test_api_internal.py
+++ b/tests/tests/test_api_internal.py
@@ -96,4 +96,4 @@ class TestInternalApiTenantCreate:
 
             artifacts_client.log.info("uploading artifact")
             with pytest.raises(ArtifactsClientError):
-                api_client_int.add_artifact(tenant_id, description, 0, art)
+                api_client_int.add_artifact(tenant_id, description, -1, art)

--- a/tests/tests/test_artifact.py
+++ b/tests/tests/test_artifact.py
@@ -155,46 +155,6 @@ class TestArtifact(ArtifactsClient):
             raise AssertionError('expected to fail')
 
     @pytest.mark.usefixtures("clean_minio")
-    def test_artifacts_generate_bogus_empty_file(self):
-        try:
-            res = self.client.artifacts.post_artifacts_generate(
-                Authorization='foo',
-                name='artifact',
-                description="bar",
-                device_types_compatible=['Beagle Bone'],
-                type='single_file',
-                args='',
-                size=100,
-                file=b'',
-            ).result()
-        except bravado.exception.HTTPError as e:
-            assert sum(1 for x in self.m.list_objects("mender-artifact-storage")) == 0
-            assert e.response.status_code == 400
-            assert 'The last part of the multipart/form-data message should be a file.' in e.response.text
-        else:
-            raise AssertionError('expected to fail')
-
-    @pytest.mark.usefixtures("clean_minio")
-    def test_artifacts_generate_bogus_wrong_size(self):
-        try:
-            res = self.client.artifacts.post_artifacts_generate(
-                Authorization='foo',
-                name='artifact',
-                description="bar",
-                device_types_compatible=['Beagle Bone'],
-                type='single_file',
-                args='',
-                size=-1,
-                file=('firmware', 'dummy'),
-            ).result()
-        except bravado.exception.HTTPError as e:
-            assert sum(1 for x in self.m.list_objects("mender-artifact-storage")) == 0
-            assert e.response.status_code == 400
-            assert 'No size provided before the file part of the message or the size value is wrong.' in e.response.text
-        else:
-            raise AssertionError('expected to fail')
-
-    @pytest.mark.usefixtures("clean_minio")
     def test_artifacts_generate_valid(self):
         artifact_name = str(uuid4())
         description = 'description for foo ' + artifact_name
@@ -206,7 +166,6 @@ class TestArtifact(ArtifactsClient):
         artid = self.generate_artifact(
             name=artifact_name,
             description=description,
-            size=len(data),
             device_types_compatible=device_type,
             type='single_file',
             args='',


### PR DESCRIPTION
The size parameter is not needed (anymoreand can be removed.

At the same time, we can make it optional in the other end-points
dealing with artifact upload (`POST /tenants/{id}/artifacts` and
`POST /artifacts`).

If it is provided, it is required to be equal to the size of the file
uploaded.

Changelog: none
Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>