### PR TITLE
Add GetArtifactUri and DeleteArtifactUri to start workflow calls

### DIFF
--- a/model/image.go
+++ b/model/image.go
@@ -147,6 +147,8 @@ type MultipartGenerateImageMsg struct {
 	Type                  string    `json:"type"`
 	Args                  string    `json:"args"`
 	ArtifactID            string    `json:"artifact_id"`
+	GetArtifactURI        string    `json:"get_artifact_uri"`
+	DeleteArtifactURI     string    `json:"delete_artifact_uri"`
 	TenantID              string    `json:"tenant_id"`
 	Token                 string    `json:"token"`
 	FileReader            io.Reader `json:"-"`

--- a/s3/mocks/FileStorage.go
+++ b/s3/mocks/FileStorage.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -76,6 +76,29 @@ func (_m *FileStorage) GetRequest(ctx context.Context, objectId string, duration
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string, time.Duration, string) error); ok {
 		r1 = rf(ctx, objectId, duration, responseContentType)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetRequest provides a mock function with given fields: ctx, objectId, duration
+func (_m *FileStorage) DeleteRequest(ctx context.Context, objectId string, duration time.Duration) (*model.Link, error) {
+	ret := _m.Called(ctx, objectId, duration)
+
+	var r0 *model.Link
+	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration) *model.Link); ok {
+		r0 = rf(ctx, objectId, duration)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Link)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, time.Duration) error); ok {
+		r1 = rf(ctx, objectId, duration)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
To allow the create artifact worker to download and delete the artifact
from S3, add the presigned get and delete URI for the artifact as
parameters to the HTTP call which starts the create_artifact workflow.

Changelog: none
Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>