### PR TITLE
api/http: return 404 when the device is updating not existing device deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ variables:
   GIT_DEPTH: 0
 
 services:
-  - docker:dind
+  - docker:19.03.5-dind
   - mongo
 
 stages:
@@ -70,7 +70,7 @@ test:prepare_acceptance:
 test:acceptance_tests:
   image: tiangolo/docker-with-compose
   services:
-    - docker:dind
+    - docker:19.03.5-dind
   stage: test
   dependencies:
     - test:build_acceptance
@@ -189,7 +189,7 @@ publish:build:
   image: docker:git
   stage: publish
   services:
-    - docker:dind
+    - docker:19.03.5-dind
   dependencies:
     - build
   script:

--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -679,6 +679,8 @@ func (d *DeploymentsApiHandlers) PutDeploymentStatusForDevice(w rest.ResponseWri
 
 		if err == app.ErrDeploymentAborted || err == app.ErrDeviceDecommissioned {
 			d.view.RenderError(w, r, err, http.StatusConflict, l)
+		} else if err == app.ErrStorageNotFound {
+			d.view.RenderErrorNotFound(w, r, l)
 		} else {
 			d.view.RenderInternalError(w, r, err, l)
 		}


### PR DESCRIPTION
When the device is trying to update status of non-existing device deployment, deployments service should return "Not Found" 404 error.