### PR TITLE
Deployments service pods get Evicted due to low DiskPressure

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -311,6 +311,8 @@ func (d *DeploymentsApiHandlers) newImageWithContext(ctx context.Context, w rest
 
 	// parse multipart message
 	multipartUploadMsg, err := d.ParseMultipart(r)
+	defer r.MultipartForm.RemoveAll()
+
 	if err != nil {
 		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return


### PR DESCRIPTION
Clean up the multipart files

 * /tmp/multipar-* files consume much of the diskspace
   kubectl exec -it mender-deployments-78c9954ff8-8jbv9 -- du -sh /tmp
   10.3G	/tmp
 * pods get Evicted from cluster
 * customers see failed or noth finished artifact uploads
 * remove all multipart left overs

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>