### PR TITLE
LookupDeployment returns total count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ debug
 __pycache__/
 *.py[cod]
 venv/
+.idea

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -403,7 +403,7 @@ func (_m *App) ListImages(ctx context.Context, filters map[string]string) ([]*mo
 }
 
 // LookupDeployment provides a mock function with given fields: ctx, query
-func (_m *App) LookupDeployment(ctx context.Context, query model.Query) ([]*model.Deployment, error) {
+func (_m *App) LookupDeployment(ctx context.Context, query model.Query) ([]*model.Deployment, int64, error) {
 	ret := _m.Called(ctx, query)
 
 	var r0 []*model.Deployment
@@ -415,14 +415,23 @@ func (_m *App) LookupDeployment(ctx context.Context, query model.Query) ([]*mode
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, model.Query) error); ok {
+	var r1 int64
+	if rf, ok := ret.Get(1).(func(context.Context, model.Query) int64); ok {
 		r1 = rf(ctx, query)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(int64)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, model.Query) error); ok {
+		r2 = rf(ctx, query)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // ProvisionTenant provides a mock function with given fields: ctx, tenant_id

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -95,7 +95,7 @@ type DataStore interface {
 	UpdateStats(ctx context.Context,
 		id string, stats model.Stats) error
 	Find(ctx context.Context,
-		query model.Query) ([]*model.Deployment, error)
+		query model.Query) ([]*model.Deployment, int64, error)
 	SetDeploymentStatus(ctx context.Context, id, status string, now time.Time) error
 	FindNewerActiveDeployments(ctx context.Context,
 		createdAfter *time.Time, skip, limit int) ([]*model.Deployment, error)

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -224,7 +224,7 @@ func (_m *DataStore) Exists(ctx context.Context, id string) (bool, error) {
 }
 
 // Find provides a mock function with given fields: ctx, query
-func (_m *DataStore) Find(ctx context.Context, query model.Query) ([]*model.Deployment, error) {
+func (_m *DataStore) Find(ctx context.Context, query model.Query) ([]*model.Deployment, int64, error) {
 	ret := _m.Called(ctx, query)
 
 	var r0 []*model.Deployment
@@ -236,14 +236,23 @@ func (_m *DataStore) Find(ctx context.Context, query model.Query) ([]*model.Depl
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, model.Query) error); ok {
+	var r1 int64
+	if rf, ok := ret.Get(1).(func(context.Context, model.Query) int64); ok {
 		r1 = rf(ctx, query)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(int64)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, model.Query) error); ok {
+		r2 = rf(ctx, query)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // FindAll provides a mock function with given fields: ctx

--- a/store/mongo/deployments_external_test.go
+++ b/store/mongo/deployments_external_test.go
@@ -1459,7 +1459,7 @@ func TestDeploymentStorageFindBy(t *testing.T) {
 				createdTime = createdTime.Add(time.Minute)
 			}
 
-			deps, err := store.Find(ctx,
+			deps, _, err := store.Find(ctx,
 				testCase.InputModelQuery)
 
 			if testCase.OutputError != nil {
@@ -1482,7 +1482,7 @@ func TestDeploymentStorageFindBy(t *testing.T) {
 				}
 
 				// output result should be stable
-				otherDeps, _ := store.Find(ctx,
+				otherDeps, _, _ := store.Find(ctx,
 					testCase.InputModelQuery)
 				assert.Equal(t, deps, otherDeps)
 
@@ -1513,7 +1513,7 @@ func TestDeploymentStorageFindBy(t *testing.T) {
 				// tenant is set, so only tenant's DB was set
 				// up, verify that we cannot find anything in
 				// default DB
-				deps, err := store.Find(context.Background(),
+				deps, _, err := store.Find(context.Background(),
 					testCase.InputModelQuery)
 				assert.Len(t, deps, 0)
 				assert.NoError(t, err)


### PR DESCRIPTION
Towards reducing API calls required for paging.

 * X-Total-Count returned in header
 * app.LookupDeployment and db.Find return int64

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>
(cherry picked from commit 9a449b25d500f2513c302ae59111cc0fc147e444)