### PR TITLE
Makefile added.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+SERVICE_NAME=deployments
+GO=go
+GOLIST=$(GO) list ./...
+GOBUILD=$(GO) build
+GOCLEAN=$(GO) clean
+GOTEST=$(GO) test
+
+all: test build
+
+build: 
+		CGO_ENABLED=1 $(GOBUILD) -o $(SERVICE_NAME)
+
+test: 
+		$(GOLIST) | grep -v /vendor | xargs -n1 -I {} -P 4 $(GOTEST) -v {}
+
+clean: 
+		$(GOCLEAN)
+		rm -f $(SERVICE_NAME)
+
+run: build
+		./$(SERVICE_NAME)
+
+run-automigrate: build
+		./$(SERVICE_NAME) server --automigrate
+


### PR DESCRIPTION
Targets:
 * all: default, calls test and build
 * build: calls `go build`
 * test: lists all modules and calls `go test`
 * clean: calls `go clean` and removes built exec file
 * run: calls build and ./service-name
 * run-automigrate: calls build and ./service-name server --automigrate

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>