### PR TITLE
s3: FIX part numbering starting from 1

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -44,6 +44,7 @@ const (
 )
 
 // maximum image size is 10G
+// NOTE: If this size increase, the buffer size in s3 client must be increased.
 const MaxImageSize = 1024 * 1024 * 1024 * 10
 
 // Errors expected from App interface

--- a/s3/filestorage.go
+++ b/s3/filestorage.go
@@ -233,7 +233,7 @@ func (s *SimpleStorageService) uploadMultipart(
 	contentType string,
 ) error {
 	const maxPartNum = 10000
-	var partNum int64
+	var partNum int64 = 1
 	var rspUpload *s3.UploadPartOutput
 
 	// Pre-allocate 100 completed part (generous guesstimate)
@@ -290,7 +290,7 @@ func (s *SimpleStorageService) uploadMultipart(
 
 	// The following is loop is very similar to io.Copy except the
 	// destination is the s3 bucket.
-	for partNum = 1; partNum < maxPartNum; partNum++ {
+	for partNum++; partNum < maxPartNum; partNum++ {
 		// Read next chunk from stream (fill the whole buffer)
 		offset, eRead := fillBuffer(buf, artifact)
 		if offset > 0 {
@@ -364,6 +364,8 @@ func (s *SimpleStorageService) UploadArtifact(
 	artifact io.Reader,
 	contentType string,
 ) error {
+	// NOTE: This size along with the 10000 part limit sets the ultimate
+	//       limit on the upload size. (currently at ~97.5GiB)
 	const multipartSize = 10 * 1024 * 1024 // 10MiB (must be at least 5MiB)
 
 	objectID = getArtifactByTenant(ctx, objectID)


### PR DESCRIPTION
Currently the part numbering starts from 0 which is causing s3 to return
an API error trying to upload artifacts. Sadly minio and hence the
acceptance tests does not cover this part of the specification so this
bug slipped through.