### PR TITLE
adjust deployment abort logic after introducing the new flow for creating deployments

### DIFF
--- a/app/status_test.go
+++ b/app/status_test.go
@@ -200,9 +200,6 @@ func TestAbortDeployment(t *testing.T) {
 
 	db.On("UpdateStats", ctx, depId, stats).Return(nil)
 
-	db.On("FindDeploymentByID", ctx, *fakeDeployment.Id).Return(
-		fakeDeployment, nil)
-
 	db.On("SetDeploymentStatus", ctx,
 		depId,
 		"finished",

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -1297,10 +1297,8 @@ func (db *DataStoreMongo) AbortDeviceDeployments(ctx context.Context,
 		},
 	}
 
-	if res, err := collDevs.UpdateMany(ctx, selector, update); err != nil {
+	if _, err := collDevs.UpdateMany(ctx, selector, update); err != nil {
 		return err
-	} else if res.MatchedCount == 0 {
-		return ErrStorageInvalidID
 	}
 
 	return nil


### PR DESCRIPTION
We should not expect device deployments to be there when aborting deployment.
With the new flow for creating deployments, device deployments are being
created on the fly, so it should be possible to abort deployment that
does not contain device deployments yet.

When aborting the deployment we also need to set status directly instead of
using recalcDeploymentStatus method.

It is possible that the deployment does not have any device deployments yet.
In that case, all statistics are 0 and calculating status based on statistics
will not work - the calculated status will be "pending".