### PR TITLE
MEN-2499: s3: use virtual-hosted style URI (v2) instead of path style

### DIFF
--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -76,6 +76,7 @@ func SetupS3(c config.Reader) (s3.FileStorage, error) {
 			c.GetString(dconfig.SettingAwsAuthToken),
 			c.GetString(dconfig.SettingAwsURI),
 			c.GetBool(dconfig.SettingsAwsTagArtifact),
+			c.GetBool(dconfig.SettingAwsS3ForcePathStyle),
 		)
 	}
 

--- a/config.yaml
+++ b/config.yaml
@@ -98,6 +98,28 @@ aws:
     
     bucket: mender-artifact-storage
 
+    # Force S3 URI style to path
+    #
+    # AWS S3 supports two diffrent URI styles:
+    # - virtual-hosted (https://bucket-name.s3.Region.amazonaws.com/key)
+    # - path-style (https://s3.Region.amazonaws.com/bucket-name/key)
+    #
+    # Buckets created after September 30, 2020, will support only virtual
+    # hosted-style requests. Path-style requests will continue to be supported
+    # for buckets created on or before this date.
+    #
+    # For more information, see Amazon S3 Path Deprecation Plan:
+    # https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
+    #
+    # When minio (or alternative S3 implementations) is in use, path
+    # style URI are used.
+    #
+    # Defaults to: true (path-style), set false to enable virtual-hosted style
+    # Overwrite with environment variable: DEPLOYMENTS_AWS_FORCE_PATH_STYLE
+
+    # force_path_style: true
+
+
     # S3 URI
     # Defaults to: none (s3.amazonaws.com)
     # Overwrite with environment variable: DEPLOYMENTS_AWS_URI

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -31,14 +31,16 @@ const (
 	SettingListen        = "listen"
 	SettingListenDefault = ":8080"
 
-	SettingsAws                   = "aws"
-	SettingAwsS3Region            = SettingsAws + ".region"
-	SettingAwsS3RegionDefault     = "us-east-1"
-	SettingAwsS3Bucket            = SettingsAws + ".bucket"
-	SettingAwsS3BucketDefault     = "mender-artifact-storage"
-	SettingAwsURI                 = SettingsAws + ".uri"
-	SettingsAwsTagArtifact        = SettingsAws + ".tag_artifact"
-	SettingsAwsTagArtifactDefault = false
+	SettingsAws                       = "aws"
+	SettingAwsS3Region                = SettingsAws + ".region"
+	SettingAwsS3RegionDefault         = "us-east-1"
+	SettingAwsS3Bucket                = SettingsAws + ".bucket"
+	SettingAwsS3BucketDefault         = "mender-artifact-storage"
+	SettingAwsS3ForcePathStyle        = SettingsAws + ".force_path_style"
+	SettingAwsS3ForcePathStyleDefault = true
+	SettingAwsURI                     = SettingsAws + ".uri"
+	SettingsAwsTagArtifact            = SettingsAws + ".tag_artifact"
+	SettingsAwsTagArtifactDefault     = false
 
 	SettingsAwsAuth      = SettingsAws + ".auth"
 	SettingAwsAuthKeyId  = SettingsAwsAuth + ".key"
@@ -121,6 +123,7 @@ var (
 		{Key: SettingListen, Value: SettingListenDefault},
 		{Key: SettingAwsS3Region, Value: SettingAwsS3RegionDefault},
 		{Key: SettingAwsS3Bucket, Value: SettingAwsS3BucketDefault},
+		{Key: SettingAwsS3ForcePathStyle, Value: SettingAwsS3ForcePathStyleDefault},
 		{Key: SettingMongo, Value: SettingMongoDefault},
 		{Key: SettingDbSSL, Value: SettingDbSSLDefault},
 		{Key: SettingDbSSLSkipVerify, Value: SettingDbSSLSkipVerifyDefault},

--- a/s3/filestorage.go
+++ b/s3/filestorage.go
@@ -71,7 +71,7 @@ type SimpleStorageService struct {
 
 // NewSimpleStorageServiceStatic create new S3 client model.
 // AWS authentication keys are automatically reloaded from env variables.
-func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri string, tag_artifact bool) (*SimpleStorageService, error) {
+func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri string, tag_artifact, forcePathStyle bool) (*SimpleStorageService, error) {
 	credentials := credentials.NewStaticCredentials(key, secret, token)
 	config := aws.NewConfig().WithCredentials(credentials).WithRegion(region)
 
@@ -80,7 +80,11 @@ func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri strin
 		config = config.WithDisableSSL(sslDisabled).WithEndpoint(uri)
 	}
 
-	config.S3ForcePathStyle = aws.Bool(true)
+	// Amazon S3 will no longer support path-style API requests starting September 30th, 2020
+	// S3 buckets created after September 30, 2020 will support only virtual-hosted style requests
+	// Setting S3ForcePathStyle to false forces virtual-hosted style.
+	config.S3ForcePathStyle = aws.Bool(forcePathStyle)
+
 	sess := session.New(config)
 
 	client := s3.New(sess)


### PR DESCRIPTION
Changelog: use S3 virtual-hosted style URI (v2) instead of path style

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>