### PR TITLE
Store DeviceCount value for Deployments in the database

### DIFF
--- a/model/deployment.go
+++ b/model/deployment.go
@@ -87,7 +87,7 @@ type Deployment struct {
 	Status string `json:"status" bson:"status"`
 
 	// Number of devices being part of the deployment
-	DeviceCount int `json:"device_count" bson:"-"`
+	DeviceCount *int `json:"device_count" bson:"device_count"`
 
 	// Total number of devices targeted
 	MaxDevices int `json:"max_devices,omitempty" bson:"max_devices"`
@@ -125,6 +125,9 @@ func NewDeploymentFromConstructor(constructor *DeploymentConstructor) (*Deployme
 
 	deployment.DeploymentConstructor = constructor
 	deployment.Status = DeploymentStatusPending
+
+	deviceCount := 0
+	deployment.DeviceCount = &deviceCount
 
 	return deployment, nil
 }

--- a/model/deployment_external_test.go
+++ b/model/deployment_external_test.go
@@ -180,7 +180,8 @@ func TestDeploymentMarshalJSON(t *testing.T) {
 	dep.ArtifactName = StringToPointer("App 123")
 	dep.Devices = []string{"Device 123"}
 	dep.Id = StringToPointer("14ddec54-30be-49bf-aa6b-97ce271d71f5")
-	dep.DeviceCount = 1337
+	deviceCount := 1337
+	dep.DeviceCount = &deviceCount
 	dep.Status = DeploymentStatusInProgress
 
 	j, err := dep.MarshalJSON()

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -101,5 +101,7 @@ type DataStore interface {
 		createdAfter *time.Time, skip, limit int) ([]*model.Deployment, error)
 	ExistUnfinishedByArtifactId(ctx context.Context, id string) (bool, error)
 	ExistByArtifactId(ctx context.Context, id string) (bool, error)
+	SetDeploymentDeviceCount(ctx context.Context, deploymentID string, count int) error
+	IncrementDeploymentDeviceCount(ctx context.Context, deploymentID string, increment int) error
 	DeviceCountByDeployment(ctx context.Context, id string) (int, error)
 }

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -118,6 +118,34 @@ func (_m *DataStore) DeleteImage(ctx context.Context, id string) error {
 	return r0
 }
 
+// SetDeploymentDeviceCount provides a mock function with given fields: ctx, deploymentID, count
+func (_m *DataStore) SetDeploymentDeviceCount(ctx context.Context, deploymentID string, count int) error {
+	ret := _m.Called(ctx, deploymentID, count)
+
+	var r0 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, int) error); ok {
+		r0 = rf(ctx, deploymentID, count)
+	} else {
+		r0 = ret.Error(1)
+	}
+
+	return r0
+}
+
+// IncrementDeploymentDeviceCount provides a mock function with given fields: ctx, deploymentID, increment
+func (_m *DataStore) IncrementDeploymentDeviceCount(ctx context.Context, deploymentID string, increment int) error {
+	ret := _m.Called(ctx, deploymentID, increment)
+
+	var r0 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, int) error); ok {
+		r0 = rf(ctx, deploymentID, increment)
+	} else {
+		r0 = ret.Error(1)
+	}
+
+	return r0
+}
+
 // DeviceCountByDeployment provides a mock function with given fields: ctx, id
 func (_m *DataStore) DeviceCountByDeployment(ctx context.Context, id string) (int, error) {
 	ret := _m.Called(ctx, id)


### PR DESCRIPTION
This commit does not include a migration; instead, when retrieving
deployments from the database, if no value is present the service
calculates it, querying and counting the number of DeviceDeployment
documents, and stores it in the document to avoid further queries to
retrieve this value.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>