### PR TITLE
MEN-3411 deploy to group of devices via PostDeployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ gover.coverprofile
 profile.coverprofile
 
 debug
+__debug_bin
 
 .vscode
 

--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -37,6 +37,7 @@ import (
 	"github.com/mendersoftware/deployments/app"
 	"github.com/mendersoftware/deployments/model"
 	"github.com/mendersoftware/deployments/store"
+	"github.com/mendersoftware/deployments/utils/pointers"
 )
 
 const (
@@ -562,7 +563,10 @@ func (d *DeploymentsApiHandlers) getDeploymentConstructorFromBody(r *rest.Reques
 		return nil, err
 	}
 
-	if err := constructor.Validate(); err != nil {
+	if len(r.PathParam("name")) > 0 {
+		constructor.Name = pointers.StringToPointer(r.PathParam("name"))
+	}
+	if err := constructor.Validate(r.PathParam("name")); err != nil {
 		return nil, err
 	}
 

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -41,6 +41,7 @@ const (
 	ApiUrlManagementArtifactsIdDownload = ApiUrlManagement + "/artifacts/:id/download"
 
 	ApiUrlManagementDeployments           = ApiUrlManagement + "/deployments"
+	ApiUrlManagementDeploymentsGroup      = ApiUrlManagement + "/deployments/group/:name"
 	ApiUrlManagementDeploymentsId         = ApiUrlManagement + "/deployments/:id"
 	ApiUrlManagementDeploymentsStatistics = ApiUrlManagement + "/deployments/:id/statistics"
 	ApiUrlManagementDeploymentsStatus     = ApiUrlManagement + "/deployments/:id/status"
@@ -142,6 +143,7 @@ func NewDeploymentsResourceRoutes(controller *DeploymentsApiHandlers) []*rest.Ro
 
 		// Deployments
 		rest.Post(ApiUrlManagementDeployments, controller.PostDeployment),
+		rest.Post(ApiUrlManagementDeploymentsGroup, controller.PostDeployment),
 		rest.Get(ApiUrlManagementDeployments, controller.LookupDeployment),
 		rest.Get(ApiUrlManagementDeploymentsId, controller.GetDeployment),
 		rest.Get(ApiUrlManagementDeploymentsStatistics, controller.GetDeploymentStats),

--- a/model/deployment.go
+++ b/model/deployment.go
@@ -25,7 +25,8 @@ import (
 
 // Errors
 var (
-	ErrInvalidDeviceID = errors.New("Invalid device ID")
+	ErrInvalidDeviceID             = errors.New("Invalid device ID")
+	ErrInvalidDeploymentDefinition = errors.New("Invalid deployments definition")
 )
 
 const (
@@ -48,7 +49,14 @@ type DeploymentConstructor struct {
 
 // Validate checks structure according to valid tags
 // TODO: Add custom validator to check devices array content (such us UUID formatting)
-func (c *DeploymentConstructor) Validate() error {
+func (c *DeploymentConstructor) Validate(groupDeployment string) error {
+	if len(groupDeployment) > 0 {
+		if c.Name == nil || len(*c.Name) < 1 {
+			return ErrInvalidDeploymentDefinition
+		}
+		return nil
+	}
+
 	if _, err := govalidator.ValidateStruct(c); err != nil {
 		return err
 	}

--- a/model/deployment_external_test.go
+++ b/model/deployment_external_test.go
@@ -91,7 +91,7 @@ func TestDeploymentConstructorValidate(t *testing.T) {
 		dep.ArtifactName = test.InputArtifactName
 		dep.Devices = test.InputDevices
 
-		err := dep.Validate()
+		err := dep.Validate("")
 
 		if !test.IsValid {
 			assert.Error(t, err)


### PR DESCRIPTION
Support deploying to given group of devices via POST to deployments/group/name

* minimal changes required to implement the feature; reused some calls
* cherry picked inventory client commit from https://github.com/mendersoftware/deployments/pull/437

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>