### PR TITLE
MEN-3646: create a new index, devices(deviceid,created,status)

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -26,8 +26,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	mopts "go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/mongo/readconcern"
-	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 
 	dconfig "github.com/mendersoftware/deployments/config"
 	"github.com/mendersoftware/deployments/model"
@@ -340,16 +338,6 @@ func NewMongoClient(ctx context.Context, c config.Reader) (*mongo.Client, error)
 		tlsConfig := &tls.Config{}
 		tlsConfig.InsecureSkipVerify = c.GetBool(dconfig.SettingDbSSLSkipVerify)
 		clientOptions.SetTLSConfig(tlsConfig)
-	}
-
-	// Set writeconcern to acknowlage after write has propagated to the
-	// mongod instance and commited to the file system journal.
-	var wc *writeconcern.WriteConcern
-	wc.WithOptions(writeconcern.W(1), writeconcern.J(true))
-	clientOptions.SetWriteConcern(wc)
-
-	if clientOptions.ReplicaSet != nil {
-		clientOptions.SetReadConcern(readconcern.Linearizable())
 	}
 
 	// Set 10s timeout

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -48,6 +48,7 @@ var (
 	IndexDeploymentArtifactName               = "deploymentArtifactNameIndex"
 	IndexDeploymentDeviceStatusesName         = "deviceIdWithStatusByCreated"
 	IndexDeploymentDeviceIdStatusName         = "devicesIdWithStatus"
+	IndexDeploymentDeviceCreatedStatusName    = "devicesIdWithCreatedStatus"
 	IndexDeploymentDeviceDeploymentIdName     = "devicesDeploymentId"
 	IndexDeploymentStatusFinishedName         = "deploymentStatusFinished"
 	IndexDeploymentStatusPendingName          = "deploymentStatusPending"
@@ -106,17 +107,29 @@ var (
 	}
 	DeviceIDStatusIndexes = mongo.IndexModel{
 		Keys: bson.D{
-			{Key: "deviceID", Value: 1},
-			{Key: "status", Value: 1},
+			{Key: StorageKeyDeviceDeploymentDeviceId, Value: 1},
+			{Key: StorageKeyDeviceDeploymentStatus, Value: 1},
 		},
 		Options: &mopts.IndexOptions{
 			Background: &_false,
 			Name:       &IndexDeploymentDeviceIdStatusName,
 		},
 	}
+	DeviceIDCreatedStatusIndex = mongo.IndexModel{
+		Keys: bson.D{
+			{Key: StorageKeyDeviceDeploymentDeviceId, Value: 1},
+			{Key: StorageKeyDeploymentStatsCreated, Value: 1},
+			{Key: StorageKeyDeviceDeploymentStatus, Value: 1},
+		},
+		Options: &mopts.IndexOptions{
+			Background: &_false,
+			Name:       &IndexDeploymentDeviceCreatedStatusName,
+		},
+	}
 	DeploymentIdIndexes = mongo.IndexModel{
 		Keys: bson.D{
-			{Key: "deploymentid", Value: 1},
+			{Key: StorageKeyDeviceDeploymentDeploymentID, Value: 1},
+			{Key: StorageKeyDeviceDeploymentDeviceId, Value: 1},
 		},
 		Options: &mopts.IndexOptions{
 			Background: &_false,

--- a/store/mongo/migration_1_2_5.go
+++ b/store/mongo/migration_1_2_5.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+	"strings"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type migration_1_2_5 struct {
+	client *mongo.Client
+	db     string
+}
+
+func (m *migration_1_2_5) Up(from migrate.Version) error {
+	ctx := context.Background()
+	storage := NewDataStoreMongoWithClient(m.client)
+	coll := m.client.Database(m.db).Collection(CollectionDevices)
+	if _, err := coll.Indexes().DropOne(ctx, IndexDeploymentDeviceStatusesName); err != nil && !strings.Contains(err.Error(), "NamespaceNotFound") {
+		// Supress NamespaceNotFound errors - index is missing
+		return err
+	}
+	if _, err := coll.Indexes().DropOne(ctx, IndexDeploymentDeviceDeploymentIdName); err != nil && !strings.Contains(err.Error(), "NamespaceNotFound") {
+		// Supress NamespaceNotFound errors - index is missing
+		return err
+	}
+	return storage.EnsureIndexes(m.db, CollectionDevices,
+		DeviceIDCreatedStatusIndex,
+		DeploymentIdIndexes,
+	)
+}
+
+func (m *migration_1_2_5) Version() migrate.Version {
+	return migrate.MakeVersion(1, 2, 5)
+}

--- a/store/mongo/migration_1_2_5_test.go
+++ b/store/mongo/migration_1_2_5_test.go
@@ -1,0 +1,97 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMigration_1_2_5(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestMigration_1_2_5 in short mode.")
+	}
+	ctx := context.Background()
+
+	testCases := map[string]struct {
+		// ST or MT naming convention
+		db    string
+		dbVer string
+
+		err error
+	}{
+		"ST, no index, 0.0.0": {
+			db:    "deployments_service",
+			dbVer: "1.2.4",
+		},
+		"MT, no index, 0.0.0": {
+			db:    "deployments_service-59afdb71c704db002a86ad95",
+			dbVer: "1.2.4",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Logf("test case: %s", name)
+
+		db.Wipe()
+		c := db.Client()
+
+		// setup
+		// setup existing migrations
+		if tc.dbVer != "" {
+			ver, err := migrate.NewVersion(tc.dbVer)
+			assert.NoError(t, err)
+			migrate.UpdateMigrationInfo(db.CTX(), *ver, c, tc.db)
+		}
+
+		migrations := []migrate.Migration{
+			&migration_1_2_5{
+				client: c,
+				db:     tc.db,
+			},
+		}
+
+		m := migrate.SimpleMigrator{
+			Client:      c,
+			Db:          tc.db,
+			Automigrate: true,
+		}
+
+		err := m.Apply(ctx, migrate.MakeVersion(1, 2, 5), migrations)
+		assert.NoError(t, err)
+
+		devicesCollectionIndicesNames := []string{
+			IndexDeploymentDeviceCreatedStatusName,
+			IndexDeploymentDeviceDeploymentIdName,
+		}
+		// verify new index is present
+		collection := c.Database(tc.db).Collection(CollectionDevices)
+		indexes := collection.Indexes()
+		cursor, _ := indexes.List(ctx)
+		for cursor.Next(ctx) {
+			var tmp map[string]interface{}
+			cursor.Decode(&tmp)
+			t.Log(tmp)
+		}
+
+		for _, indexName := range devicesCollectionIndicesNames {
+			hasNew, err := hasIndex(ctx, indexName, indexes)
+			assert.NoError(t, err)
+			assert.True(t, hasNew)
+		}
+	}
+}

--- a/store/mongo/migrations.go
+++ b/store/mongo/migrations.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	DbVersion = "1.2.4"
+	DbVersion = "1.2.5"
 	DbName    = "deployment_service"
 )
 
@@ -94,6 +94,10 @@ func MigrateSingle(ctx context.Context,
 			db:     db,
 		},
 		&migration_1_2_4{
+			client: client,
+			db:     db,
+		},
+		&migration_1_2_5{
 			client: client,
 			db:     db,
 		},


### PR DESCRIPTION
Migration: 1.2.5; drop the rendundant index devices(deviceid, status,
created), create a new index devices(deviceid, created, status) which
allows us to select the oldest deployment for a deviceid with a given
status.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>