### PR TITLE
API spec fixes: schema and hostname

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -7,7 +7,7 @@ info:
 
     Devices can get new updates and send information about current deployment status.
 
-host: 'docker.mender.io'
+host: 'hosted.mender.io'
 basePath: '/api/devices/v1/deployments'
 schemes:
   - https

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -5,7 +5,7 @@ info:
   description: |
     Internal API of deployments service
 
-host: 'docker.mender.io'
+host: 'mender-deployments:8080'
 basePath: '/api/internal/v1/deployments'
 schemes:
   - http

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -8,7 +8,7 @@ info:
 host: 'docker.mender.io'
 basePath: '/api/internal/v1/deployments'
 schemes:
-  - https
+  - http
 
 responses:
   NotFoundError: # 404

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -6,7 +6,7 @@ info:
     An API for deployments and artifacts management.
     Intended for use by the web GUI.
 
-host: 'docker.mender.io'
+host: 'hosted.mender.io'
 basePath: '/api/management/v1/deployments'
 schemes:
   - https


### PR DESCRIPTION
* [API spec] Consistently use host hosted.mender.io across all repos
* [API spec] Consistently use https schemes across all repos