### PR TITLE
management_api.yml: fix broken link to docs.mender.io (again)

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -514,7 +514,7 @@ paths:
       description: |
         Upload mender artifact. Multipart request with meta and artifact.
 
-        Supports artifact [versions v1, v2, 3](https://https://docs.mender.io/overview/artifact#versions).
+        Supports artifact [versions v1, v2, 3](https://docs.mender.io/overview/artifact#versions).
       consumes:
         - multipart/form-data
       parameters:


### PR DESCRIPTION
Fixes 56ee71be8 ("management_api.yml: fix broken link to docs.mender.io")

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>