### PR TITLE
api: Generate artifact doesn't load entire request upon parsing

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -406,20 +406,25 @@ func formatArtifactUploadError(err error) error {
 func (d *DeploymentsApiHandlers) GenerateImage(w rest.ResponseWriter, r *rest.Request) {
 	l := requestlog.GetRequestLogger(r)
 
-	err := r.ParseMultipartForm(DefaultMaxMetaSize)
+	formReader, err := r.MultipartReader()
 	if err != nil {
 		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
 	// parse multipart message
-	multipartGenerateImageMsg, err := d.ParseGenerateImageMultipart(r)
+	multipartMsg, err := d.ParseGenerateImageMultipart(formReader)
 	if err != nil {
 		d.view.RenderError(w, r, err, http.StatusBadRequest, l)
 		return
 	}
 
-	imgID, err := d.app.GenerateImage(r.Context(), multipartGenerateImageMsg)
+	tokenFields := strings.Fields(r.Header.Get("Authorization"))
+	if len(tokenFields) == 2 && strings.EqualFold(tokenFields[0], "Bearer") {
+		multipartMsg.Token = tokenFields[1]
+	}
+
+	imgID, err := d.app.GenerateImage(r.Context(), multipartMsg)
 	cause := errors.Cause(err)
 	switch cause {
 	default:
@@ -438,8 +443,6 @@ func (d *DeploymentsApiHandlers) GenerateImage(w rest.ResponseWriter, r *rest.Re
 		l.Error(err.Error())
 		d.view.RenderError(w, r, cause, http.StatusBadRequest, l)
 	}
-
-	return
 }
 
 // ParseMultipart parses multipart/form-data message.
@@ -515,44 +518,75 @@ func (d *DeploymentsApiHandlers) ParseMultipart(r *multipart.Reader) (*model.Mul
 }
 
 // ParseGenerateImageMultipart parses multipart/form-data message.
-func (d *DeploymentsApiHandlers) ParseGenerateImageMultipart(r *rest.Request) (*model.MultipartGenerateImageMsg, error) {
-	multipartGenerateImageMsg := &model.MultipartGenerateImageMsg{}
+func (d *DeploymentsApiHandlers) ParseGenerateImageMultipart(r *multipart.Reader) (*model.MultipartGenerateImageMsg, error) {
+	msg := &model.MultipartGenerateImageMsg{}
 
-	multipartGenerateImageMsg.Name = r.Form.Get("name")
-	if multipartGenerateImageMsg.Name == "" {
-		return nil, ErrArtifactNameMissing
+ParseLoop:
+	for {
+		part, err := r.NextPart()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		switch strings.ToLower(part.FormName()) {
+		case "args":
+			b, err := ioutil.ReadAll(part)
+			if err != nil {
+				return nil, errors.Wrap(err,
+					"failed to read form value 'args'",
+				)
+			}
+			msg.Args = string(b)
+
+		case "description":
+			b, err := ioutil.ReadAll(part)
+			if err != nil {
+				return nil, errors.Wrap(err,
+					"failed to read form value 'description'",
+				)
+			}
+			msg.Description = string(b)
+
+		case "device_types_compatible":
+			b, err := ioutil.ReadAll(part)
+			if err != nil {
+				return nil, errors.Wrap(err,
+					"failed to read form value 'device_types_compatible'",
+				)
+			}
+			msg.DeviceTypesCompatible = strings.Split(string(b), ",")
+
+		case "file":
+			msg.FileReader = part
+			break ParseLoop
+
+		case "name":
+			b, err := ioutil.ReadAll(part)
+			if err != nil {
+				return nil, errors.Wrap(err,
+					"failed to read form value 'name'",
+				)
+			}
+			msg.Name = string(b)
+
+		case "type":
+			b, err := ioutil.ReadAll(part)
+			if err != nil {
+				return nil, errors.Wrap(err,
+					"failed to read form value 'type'",
+				)
+			}
+			msg.Type = string(b)
+
+		default:
+			// Ignore non-API sections.
+			continue
+		}
 	}
 
-	multipartGenerateImageMsg.Description = r.Form.Get("description")
-
-	multipartGenerateImageMsg.Type = r.Form.Get("type")
-	if multipartGenerateImageMsg.Type == "" {
-		return nil, ErrArtifactTypeMissing
-	}
-
-	multipartGenerateImageMsg.Args = r.Form.Get("args")
-
-	deviceTypesCompatible := r.Form.Get("device_types_compatible")
-	if deviceTypesCompatible == "" {
-		return nil, ErrArtifactDeviceTypesCompatibleMissing
-	}
-
-	multipartGenerateImageMsg.DeviceTypesCompatible = strings.Split(deviceTypesCompatible, ",")
-
-	file, fileHeader, err := r.FormFile("file")
-	if err != nil {
-		return nil, ErrArtifactFileMissing
-	}
-
-	multipartGenerateImageMsg.FileReader = file
-	multipartGenerateImageMsg.Size = fileHeader.Size
-
-	auth := strings.Split(r.Header.Get(HTTPHeaderAuthorization), " ")
-	if len(auth) == 2 && auth[0] == HTTPHeaderAuthorizationBearer {
-		multipartGenerateImageMsg.Token = auth[1]
-	}
-
-	return multipartGenerateImageMsg, nil
+	return msg, errors.Wrap(msg.Validate(), "api: invalid form parameters")
 }
 
 // deployments

--- a/api/http/images_test.go
+++ b/api/http/images_test.go
@@ -413,7 +413,7 @@ func TestPostArtifactsGenerate(t *testing.T) {
 			requestBodyObject:  []h.Part{},
 			requestContentType: "",
 			responseCode:       http.StatusBadRequest,
-			responseBody:       "mime: no media type",
+			responseBody:       "request Content-Type isn't multipart/form-data",
 		},
 		{
 			requestBodyObject:  []h.Part{},
@@ -425,7 +425,7 @@ func TestPostArtifactsGenerate(t *testing.T) {
 			requestBodyObject:  []h.Part{},
 			requestContentType: "multipart/form-data",
 			responseCode:       http.StatusBadRequest,
-			responseBody:       "request does not contain the name of the artifact",
+			responseBody:       "api: invalid form parameters:",
 		},
 		{
 			requestBodyObject: []h.Part{
@@ -445,7 +445,8 @@ func TestPostArtifactsGenerate(t *testing.T) {
 			},
 			requestContentType: "multipart/form-data",
 			responseCode:       http.StatusBadRequest,
-			responseBody:       "request does not contain the list of compatible device types",
+			responseBody: "api: invalid form parameters: " +
+				"device_types_compatible: non zero value required",
 		},
 		{
 			requestBodyObject: []h.Part{
@@ -464,7 +465,7 @@ func TestPostArtifactsGenerate(t *testing.T) {
 			},
 			requestContentType: "multipart/form-data",
 			responseCode:       http.StatusBadRequest,
-			responseBody:       "request does not contain the artifact file",
+			responseBody:       "api: invalid form parameters: missing 'file' section",
 		},
 		{
 			requestBodyObject: []h.Part{
@@ -484,7 +485,7 @@ func TestPostArtifactsGenerate(t *testing.T) {
 			},
 			requestContentType: "multipart/form-data",
 			responseCode:       http.StatusBadRequest,
-			responseBody:       "request does not contain the type of artifact",
+			responseBody:       "api: invalid form parameters: type: non zero value required",
 		},
 		{
 			requestBodyObject: []h.Part{
@@ -735,11 +736,8 @@ func TestPostArtifactsGenerate(t *testing.T) {
 				app.On("GenerateImage",
 					h.ContextMatcher(),
 					mock.MatchedBy(func(msg *model.MultipartGenerateImageMsg) bool {
-						size, _ := strconv.Atoi(tc.requestBodyObject[2].FieldValue)
-
 						assert.Equal(t, msg.Name, tc.requestBodyObject[0].FieldValue)
 						assert.Equal(t, msg.Description, tc.requestBodyObject[1].FieldValue)
-						assert.Equal(t, msg.Size, int64(size))
 						assert.Equal(t, msg.DeviceTypesCompatible, []string{tc.requestBodyObject[3].FieldValue})
 						assert.Equal(t, msg.Type, tc.requestBodyObject[4].FieldValue)
 						assert.Equal(t, msg.Args, tc.requestBodyObject[5].FieldValue)

--- a/app/app.go
+++ b/app/app.go
@@ -35,6 +35,7 @@ import (
 	"github.com/mendersoftware/deployments/s3"
 	"github.com/mendersoftware/deployments/store"
 	"github.com/mendersoftware/deployments/store/mongo"
+	"github.com/mendersoftware/deployments/utils"
 )
 
 const (
@@ -234,10 +235,11 @@ func (d *Deployments) handleArtifact(ctx context.Context,
 	pR, pW := io.Pipe()
 
 	// limit reader to the size provided with the upload message
-	lr := io.LimitReader(
-		multipartUploadMsg.ArtifactReader,
-		multipartUploadMsg.ArtifactSize+1,
-	).(*io.LimitedReader)
+	lr := &utils.LimitedReader{
+		R:          multipartUploadMsg.ArtifactReader,
+		N:          multipartUploadMsg.ArtifactSize + 1,
+		LimitError: ErrModelArtifactFileTooLarge,
+	}
 	tee := io.TeeReader(lr, pW)
 
 	uid, err := uuid.FromString(multipartUploadMsg.ArtifactID)
@@ -253,14 +255,16 @@ func (d *Deployments) handleArtifact(ctx context.Context,
 	// and cannot be done in the same goroutine as writing to the pipe
 	//
 	// uploading and parsing artifact in the same process will cause in a deadlock!
-	go func() {
-		err := d.fileStorage.UploadArtifact(
+	//nolint:errcheck
+	go func() (err error) {
+		defer func() { ch <- err }()
+		err = d.fileStorage.UploadArtifact(
 			ctx, artifactID, pR, ArtifactContentType,
 		)
 		if err != nil {
 			pR.CloseWithError(err)
 		}
-		ch <- err
+		return err
 	}()
 
 	// parse artifact
@@ -280,12 +284,8 @@ func (d *Deployments) handleArtifact(ctx context.Context,
 		pW.CloseWithError(err)
 		<-ch
 		return artifactID, err
-	} else if lr.N <= 0 {
-		// LimitReader exhausted, artifact file too large.
-		pW.CloseWithError(ErrModelArtifactFileTooLarge)
-		<-ch
-		return "", ErrModelArtifactFileTooLarge
 	}
+
 	// close the pipe
 	pW.Close()
 
@@ -329,11 +329,8 @@ func (d *Deployments) handleArtifact(ctx context.Context,
 func (d *Deployments) GenerateImage(ctx context.Context,
 	multipartGenerateImageMsg *model.MultipartGenerateImageMsg) (string, error) {
 
-	switch {
-	case multipartGenerateImageMsg == nil:
+	if multipartGenerateImageMsg == nil {
 		return "", ErrModelMultipartUploadMsgMalformed
-	case multipartGenerateImageMsg.Size > MaxImageSize:
-		return "", ErrModelArtifactFileTooLarge
 	}
 
 	imgID, err := d.handleRawFile(ctx, multipartGenerateImageMsg)
@@ -373,7 +370,7 @@ func (d *Deployments) GenerateImage(ctx context.Context,
 // and starts the workflow to generate the artifact.
 // Returns image ID, artifact file ID and nil on success.
 func (d *Deployments) handleRawFile(ctx context.Context,
-	multipartGenerateImageMsg *model.MultipartGenerateImageMsg) (string, error) {
+	multipartMsg *model.MultipartGenerateImageMsg) (string, error) {
 
 	uid := uuid.NewV4()
 	artifactID := uid.String()
@@ -382,7 +379,9 @@ func (d *Deployments) handleRawFile(ctx context.Context,
 	// artifact is considered to be unique if there is no artifact with the same name
 	// and supporting the same platform in the system
 	isArtifactUnique, err := d.db.IsArtifactUnique(ctx,
-		multipartGenerateImageMsg.Name, multipartGenerateImageMsg.DeviceTypesCompatible)
+		multipartMsg.Name,
+		multipartMsg.DeviceTypesCompatible,
+	)
 	if err != nil {
 		return "", errors.Wrap(err, "Fail to check if artifact is unique")
 	}
@@ -390,9 +389,14 @@ func (d *Deployments) handleRawFile(ctx context.Context,
 		return "", ErrModelArtifactNotUnique
 	}
 
-	lr := io.LimitReader(multipartGenerateImageMsg.FileReader, multipartGenerateImageMsg.Size)
+	file := &utils.LimitedReader{
+		R:          multipartMsg.FileReader,
+		N:          MaxImageSize + 1,
+		LimitError: ErrModelArtifactFileTooLarge,
+	}
+
 	err = d.fileStorage.UploadArtifact(
-		ctx, artifactID, lr, ArtifactContentType,
+		ctx, artifactID, file, ArtifactContentType,
 	)
 	if err != nil {
 		return "", err

--- a/app/images_test.go
+++ b/app/images_test.go
@@ -31,6 +31,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+type BogusReader struct{}
+
+func (r *BogusReader) Read(b []byte) (int, error) {
+	return len(b), nil
+}
+
 func TestGenerateImageError(t *testing.T) {
 	db := mocks.DataStore{}
 	fs := &fs_mocks.FileStorage{}
@@ -43,12 +49,6 @@ func TestGenerateImageError(t *testing.T) {
 		{
 			multipartGenerateImage: nil,
 			expectedError:          ErrModelMultipartUploadMsgMalformed,
-		},
-		{
-			multipartGenerateImage: &model.MultipartGenerateImageMsg{
-				Size: MaxImageSize + 1,
-			},
-			expectedError: ErrModelArtifactFileTooLarge,
 		},
 	}
 
@@ -82,7 +82,6 @@ func TestGenerateImageArtifactIsNotUnique(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "",
-		Size:                  10,
 		FileReader:            nil,
 	}
 
@@ -113,7 +112,6 @@ func TestGenerateImageErrorWhileCheckingIfArtifactIsNotUnique(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "",
-		Size:                  10,
 		FileReader:            nil,
 	}
 
@@ -135,7 +133,7 @@ func TestGenerateImageErrorWhileUploading(t *testing.T) {
 	fs.On("UploadArtifact",
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("*io.LimitedReader"),
+		mock.AnythingOfType("*utils.LimitedReader"),
 		mock.AnythingOfType("string"),
 	).Return(errors.New("error while uploading"))
 
@@ -151,7 +149,6 @@ func TestGenerateImageErrorWhileUploading(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "",
-		Size:                  10,
 		FileReader:            bytes.NewReader([]byte("123456790")),
 	}
 
@@ -174,7 +171,7 @@ func TestGenerateImageErrorS3GetRequest(t *testing.T) {
 	fs.On("UploadArtifact",
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("*io.LimitedReader"),
+		mock.AnythingOfType("*utils.LimitedReader"),
 		mock.AnythingOfType("string"),
 	).Return(nil)
 
@@ -198,7 +195,6 @@ func TestGenerateImageErrorS3GetRequest(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "",
-		Size:                  10,
 		FileReader:            bytes.NewReader([]byte("123456790")),
 	}
 
@@ -221,7 +217,7 @@ func TestGenerateImageErrorS3DeleteRequest(t *testing.T) {
 	fs.On("UploadArtifact",
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("*io.LimitedReader"),
+		mock.AnythingOfType("*utils.LimitedReader"),
 		mock.AnythingOfType("string"),
 	).Return(nil)
 
@@ -253,7 +249,6 @@ func TestGenerateImageErrorS3DeleteRequest(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "",
-		Size:                  10,
 		FileReader:            bytes.NewReader([]byte("123456790")),
 	}
 
@@ -303,7 +298,7 @@ func TestGenerateImageErrorWhileStartingWorkflow(t *testing.T) {
 	fs.On("UploadArtifact",
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("*io.LimitedReader"),
+		mock.AnythingOfType("*utils.LimitedReader"),
 		mock.AnythingOfType("string"),
 	).Return(nil)
 
@@ -324,7 +319,6 @@ func TestGenerateImageErrorWhileStartingWorkflow(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "",
-		Size:                  10,
 		FileReader:            bytes.NewReader([]byte("123456790")),
 	}
 
@@ -375,7 +369,7 @@ func TestGenerateImageErrorWhileStartingWorkflowAndFailsWhenCleaningUp(t *testin
 	fs.On("UploadArtifact",
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("*io.LimitedReader"),
+		mock.AnythingOfType("*utils.LimitedReader"),
 		mock.AnythingOfType("string"),
 	).Return(nil)
 
@@ -396,7 +390,6 @@ func TestGenerateImageErrorWhileStartingWorkflowAndFailsWhenCleaningUp(t *testin
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "",
-		Size:                  10,
 		FileReader:            bytes.NewReader([]byte("123456790")),
 	}
 
@@ -424,7 +417,6 @@ func TestGenerateImageSuccessful(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "args",
-		Size:                  10,
 		FileReader:            bytes.NewReader([]byte("123456790")),
 	}
 
@@ -458,7 +450,7 @@ func TestGenerateImageSuccessful(t *testing.T) {
 	fs.On("UploadArtifact",
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("*io.LimitedReader"),
+		mock.AnythingOfType("*utils.LimitedReader"),
 		mock.AnythingOfType("string"),
 	).Return(nil)
 
@@ -490,7 +482,6 @@ func TestGenerateImageSuccessfulWithTenant(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "args",
-		Size:                  10,
 		FileReader:            bytes.NewReader([]byte("123456790")),
 	}
 
@@ -522,7 +513,7 @@ func TestGenerateImageSuccessfulWithTenant(t *testing.T) {
 	fs.On("UploadArtifact",
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
-		mock.AnythingOfType("*io.LimitedReader"),
+		mock.AnythingOfType("*utils.LimitedReader"),
 		mock.AnythingOfType("string"),
 	).Return(nil)
 

--- a/client/workflows/client_test.go
+++ b/client/workflows/client_test.go
@@ -134,7 +134,6 @@ func TestGenerateArtifactFails(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "",
-		Size:                  10,
 		TenantID:              "tenant_id",
 		ArtifactID:            "artifact_id",
 		FileReader:            bytes.NewReader([]byte("123456790")),
@@ -178,7 +177,6 @@ func TestGenerateArtifactSuccessful(t *testing.T) {
 		DeviceTypesCompatible: []string{"Beagle Bone"},
 		Type:                  "single_file",
 		Args:                  "args",
-		Size:                  10,
 		TenantID:              "tenant_id",
 		ArtifactID:            "artifact_id",
 		FileReader:            bytes.NewReader([]byte("123456790")),
@@ -196,7 +194,6 @@ func TestGenerateArtifactSuccessful(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "name", multipartGenerateImage.Name)
 	assert.Equal(t, "description", multipartGenerateImage.Description)
-	assert.Equal(t, int64(10), multipartGenerateImage.Size)
 	assert.Len(t, multipartGenerateImage.DeviceTypesCompatible, 1)
 	assert.Equal(t, "Beagle Bone", multipartGenerateImage.DeviceTypesCompatible[0])
 	assert.Equal(t, "single_file", multipartGenerateImage.Type)

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,6 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mendersoftware/go-lib-micro v0.0.0-20201013131806-cf1f6a851bcb h1:bRFZW2Q1Bz4OW4SOZrymlP2CtgfDKAlTu9X97Vm6bIQ=
 github.com/mendersoftware/go-lib-micro v0.0.0-20201013131806-cf1f6a851bcb/go.mod h1:ZjLBGCFWe67uSPXCLULel6j8Rf3KSZX1XjvWABIKAkE=
-github.com/mendersoftware/mender-artifact v0.0.0-20201014114809-a3fb141f8c09 h1:Q4O8xxcX19ytT9Z3KV7arQLx2RJYvtC0CClsvOS8PEw=
-github.com/mendersoftware/mender-artifact v0.0.0-20201014114809-a3fb141f8c09/go.mod h1:0WP2ZiHCDj6A88zCHjbSx4F6tKZ+RxUo+EHgnl+v6PM=
 github.com/mendersoftware/mender-artifact v0.0.0-20201119081602-3f57f208c23e h1:+C5P3I6Ul3rGvIc3t24K1t7z4hc9Xwq4xP4Q+F8NYQo=
 github.com/mendersoftware/mender-artifact v0.0.0-20201119081602-3f57f208c23e/go.mod h1:uu7kTE8/9KpCtuVI2wSpbbirWnScqXsw5kTDk1wYBXU=
 github.com/mendersoftware/mendertesting v0.0.1 h1:Uh3yPaHLEC+27y8ZBpDLtwE1LZaPclKuNBCH+A3oRI4=

--- a/model/image.go
+++ b/model/image.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	"github.com/mendersoftware/go-lib-micro/mongo/doc"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
@@ -200,16 +201,26 @@ type MultipartUploadMsg struct {
 // MultipartGenerateImageMsg is a structure with fields extracted from the multipart/form-data
 // form sent in the artifact generation request
 type MultipartGenerateImageMsg struct {
-	Name                  string    `json:"name"`
-	Description           string    `json:"description"`
-	Size                  int64     `json:"size"`
-	DeviceTypesCompatible []string  `json:"device_types_compatible"`
-	Type                  string    `json:"type"`
-	Args                  string    `json:"args"`
-	ArtifactID            string    `json:"artifact_id"`
-	GetArtifactURI        string    `json:"get_artifact_uri"`
-	DeleteArtifactURI     string    `json:"delete_artifact_uri"`
-	TenantID              string    `json:"tenant_id"`
-	Token                 string    `json:"token"`
-	FileReader            io.Reader `json:"-"`
+	Name                  string    `json:"name" valid:"required"`
+	Description           string    `json:"description" valid:"-"`
+	DeviceTypesCompatible []string  `json:"device_types_compatible" valid:"required"`
+	Type                  string    `json:"type" valid:"required"`
+	Args                  string    `json:"args" valid:"-"`
+	ArtifactID            string    `json:"artifact_id" valid:"-"`
+	GetArtifactURI        string    `json:"get_artifact_uri" valid:"-"`
+	DeleteArtifactURI     string    `json:"delete_artifact_uri" valid:"-"`
+	TenantID              string    `json:"tenant_id" valid:"-"`
+	Token                 string    `json:"token" valid:"-"`
+	FileReader            io.Reader `json:"-" valid:"required"`
+}
+
+func (msg MultipartGenerateImageMsg) Validate() error {
+	_, err := govalidator.ValidateStruct(msg)
+	if err == nil {
+		// Somehow FileReader is not covered by "required" rule.
+		if msg.FileReader == nil {
+			return errors.New("missing 'file' section")
+		}
+	}
+	return err
 }

--- a/utils/io.go
+++ b/utils/io.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import "io"
+
+// A LimitedReader reads from R but limits the amount of
+// data returned to just N bytes. Each call to Read
+// updates N to reflect the new amount remaining.
+// Read returns LimitError when N <= 0.
+// Redefinition of standard interface io.LimitedReader, with
+// variable error.
+type LimitedReader struct {
+	R          io.Reader // underlying reader
+	N          int64     // max bytes remaining
+	LimitError error     // error returned when reaching the limit
+}
+
+func (l *LimitedReader) Read(p []byte) (n int, err error) {
+	if l.N <= 0 {
+		return 0, l.LimitError
+	}
+	if int64(len(p)) > l.N {
+		p = p[0:l.N]
+	}
+	n, err = l.R.Read(p)
+	l.N -= int64(n)
+	return
+}

--- a/utils/io_test.go
+++ b/utils/io_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type NoopReader struct{}
+
+func (r NoopReader) Read(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func TestLimitedReader(t *testing.T) {
+	lr := &LimitedReader{
+		R:          NoopReader{},
+		N:          48,
+		LimitError: errors.New("bogus error"),
+	}
+	b := make([]byte, 32)
+
+	n, err := lr.Read(b)
+	assert.NoError(t, err)
+	assert.Equal(t, 32, n)
+
+	n, err = lr.Read(b)
+	assert.NoError(t, err)
+	assert.Equal(t, 16, n)
+
+	n, err = lr.Read(b)
+	assert.EqualError(t, err, "bogus error")
+	assert.Equal(t, 0, n)
+}


### PR DESCRIPTION
Parses the multipart request form fields sequentially without reading
the entire request into memory and disk.
I also added a new LimitedReader interface with a custom error so that
the s3 package aborts the ongoing multipart upload if the file is too large.