### PR TITLE
fix mongo migration index not found error

### DIFF
--- a/store/mongo/migration_1_2_1.go
+++ b/store/mongo/migration_1_2_1.go
@@ -16,6 +16,7 @@ package mongo
 import (
 	"github.com/globalsign/mgo"
 	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"strings"
 )
 
 type migration_1_2_1 struct {
@@ -36,7 +37,7 @@ func (m *migration_1_2_1) Up(from migrate.Version) error {
 
 	// 'ns not found' simply means the idx doesn't exist
 	// DropIndex is just not idempotent, so force it
-	if err != nil && err.Error() != "ns not found" && err.Error() != "index not found with name" {
+	if err != nil && err.Error() != "ns not found" && !strings.HasPrefix(err.Error(), "index not found with name") {
 		return err
 	}
 


### PR DESCRIPTION
**Issue** : mender deployments fails to start
**RCA** :  the index not found error message by mongo contains the name of the index as well
The error message by mender during migration is 
`time="2020-12-07T05:40:51Z" level=error msg="migration from 0.0.0 to 1.2.1 failed: index not found with name [deploymentconstructor.name_text_deploymentconstructor.artifactname_text]" db=deployment_service file=migrator_simple.go func="migrate.(*SimpleMigrator).Apply" line=106`
**Fix** : use strings.HasPrefix to check the type of error message instead of equating it directly