### PR TITLE
store: Make error detection in migration 1.2.1 more robust

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -40,6 +40,13 @@ const (
 	CollectionDevices              = "devices"
 )
 
+// Internal status codes from
+// https://github.com/mongodb/mongo/blob/4.4/src/mongo/base/error_codes.yml
+const (
+	errorCodeNamespaceNotFound = 26
+	errorCodeIndexNotFound     = 27
+)
+
 var (
 	// Indexes (version: 1.2.2)
 	IndexUniqueNameAndDeviceTypeName          = "uniqueNameAndDeviceTypeIndex"


### PR DESCRIPTION
Error messages returned from the MongoDB server has proven not to be
immutable (#520). This commit moves the error detection to check the
more stable error code returned by the server.