### PR TITLE
Fix deployment group being removed from object after resolving device…

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -638,7 +638,7 @@ func (d *DeploymentsApiHandlers) getDeploymentConstructorFromBody(r *rest.Reques
 
 	constructor.Group = group
 
-	if err := constructor.Validate(); err != nil {
+	if err := constructor.ValidateNew(); err != nil {
 		return nil, err
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -700,7 +700,6 @@ func (d *Deployments) updateDeploymentConstructor(ctx context.Context,
 		}
 		searchParams.Page++
 	}
-	constructor.Group = ""
 
 	return constructor, nil
 }

--- a/model/deployment.go
+++ b/model/deployment.go
@@ -70,11 +70,15 @@ type DeploymentConstructor struct {
 // Validate checks structure according to valid tags
 // TODO: Add custom validator to check devices array content (such us UUID formatting)
 func (c DeploymentConstructor) Validate() error {
-	if err := validation.ValidateStruct(&c,
+	return validation.ValidateStruct(&c,
 		validation.Field(&c.Name, validation.Required, lengthIn1To4096),
 		validation.Field(&c.ArtifactName, validation.Required, lengthIn1To4096),
 		validation.Field(&c.Devices, validation.Each(validation.Required)),
-	); err != nil {
+	)
+}
+
+func (c DeploymentConstructor) ValidateNew() error {
+	if err := c.Validate(); err != nil {
 		return err
 	}
 
@@ -90,7 +94,6 @@ func (c DeploymentConstructor) Validate() error {
 			return ErrInvalidDeploymentToGroupDefinitionConflict
 		}
 	}
-
 	return nil
 }
 

--- a/model/deployment_external_test.go
+++ b/model/deployment_external_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -128,7 +129,7 @@ func TestDeploymentConstructorValidate(t *testing.T) {
 		dep.Group = test.InputGroup
 		dep.AllDevices = test.InputAllDevices
 
-		err := dep.Validate()
+		err := dep.ValidateNew()
 
 		if !test.IsValid {
 			assert.Error(t, err)
@@ -178,31 +179,26 @@ func TestDeploymentValidate(t *testing.T) {
 			InputDevices:      []string{"f826484e-1157-4109-af21-304e6d711560"},
 			IsValid:           true,
 		},
-		{
-			InputName:         "f826484e-1157-4109-af21-304e6d711560",
-			InputArtifactName: "f826484e-1157-4109-af21-304e6d711560",
-			InputDevices:      []string{},
-			IsValid:           false,
-		},
 	}
 
-	for _, test := range testCases {
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("test #%d", i), func(t *testing.T) {
+			pub := &DeploymentConstructor{}
+			pub.Name = test.InputName
+			pub.ArtifactName = test.InputArtifactName
+			pub.Devices = test.InputDevices
 
-		pub := &DeploymentConstructor{}
-		pub.Name = test.InputName
-		pub.ArtifactName = test.InputArtifactName
-		pub.Devices = test.InputDevices
-
-		dep, err := NewDeploymentFromConstructor(pub)
-		assert.NoError(t, err)
-
-		err = dep.Validate()
-
-		if !test.IsValid {
-			assert.Error(t, err)
-		} else {
+			dep, err := NewDeploymentFromConstructor(pub)
 			assert.NoError(t, err)
-		}
+
+			err = dep.Validate()
+
+			if !test.IsValid {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 
 }


### PR DESCRIPTION
… ids

This was a mistake introduced by 5dc6edebb2cdb38c531ad9d4d4d09eadf9c6527f
where the group is cleared from the document after resolving the device
ids.
changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>