### PR TITLE
tests: remove dependency on storage-proxy

### DIFF
--- a/tests/docker-compose-acceptance-enterprise.yml
+++ b/tests/docker-compose-acceptance-enterprise.yml
@@ -11,7 +11,7 @@ services:
             - mender-inventory
             - mender-workflows-server
             - minio
-            - storage-proxy
+            - mender-api-gateway
     mender-deployments:
             # built/tagged locally and only used for testing
             image: mendersoftware/deployments:prtest

--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -12,7 +12,7 @@ services:
             - mender-inventory
             - mender-workflows-server
             - minio
-            - storage-proxy
+            - mender-api-gateway
     mender-deployments:
             # built/tagged locally and only used for testing
             image: mendersoftware/deployments:prtest


### PR DESCRIPTION
_another missing piece after traefik migration.
@alfrunes this is with regards to your issues in https://github.com/mendersoftware/deployments/pull/541_

---
it's what used to own the `s3.docker.mender.io` alias,
that deployments needs as usual.

fix on 2 levels:
- make tests runnable by removing the dependency
- make tests green by actually setting up the alias again

currently, the gateway owns this alias, so even though we don't
'need' it - add it to the test setup _(EDIT: not really add - just wait on it)_

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>