### PR TITLE
MEN-4427: Generate configuration artifacts on-the-fly on /deployments/next requests

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -1044,9 +1044,15 @@ func (d *DeploymentsApiHandlers) GetDeploymentForDevice(w rest.ResponseWriter, r
 		return
 	} else if deployment.Type == model.DeploymentTypeConfiguration {
 		// Generate pre-signed URL
-		var hostName string
-		if hostName = r.Header.Get("X-Forwarded-Host"); hostName == "" {
-			hostName = d.config.PresignHostname
+		var hostName string = d.config.PresignHostname
+		if hostName == "" {
+			if hostName = r.Header.Get(hdrForwardedHost); hostName == "" {
+				d.view.RenderInternalError(w, r,
+					errors.New("presign.hostname not configured; "+
+						"unable to generate download link "+
+						" for configuration deployment"), l)
+				return
+			}
 		}
 		req, _ := http.NewRequest(
 			http.MethodGet,

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -191,6 +191,7 @@ func NewDeploymentsResourceRoutes(controller *DeploymentsApiHandlers) []*rest.Ro
 
 		// Devices
 		rest.Get(ApiUrlDevicesDeploymentsNext, controller.GetDeploymentForDevice),
+		rest.Post(ApiUrlDevicesDeploymentsNext, controller.GetDeploymentForDevice),
 		rest.Put(ApiUrlDevicesDeploymentStatus,
 			controller.PutDeploymentStatusForDevice),
 		rest.Put(ApiUrlDevicesDeploymentsLog,

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -17,7 +17,6 @@ package http
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"strings"
 	"time"
 
@@ -241,9 +240,9 @@ func ReleasesRoutes(controller *DeploymentsApiHandlers) []*rest.Route {
 
 func FMTConfigURL(scheme, hostname, deploymentID, deviceType, deviceID string) string {
 	repl := strings.NewReplacer(
-		":deployment_id", deploymentID,
-		":device_type", deviceType,
-		":device_id", deviceID,
+		":"+ParamDeploymentID, deploymentID,
+		":"+ParamDeviceType, deviceType,
+		":"+ParamDeviceID, deviceID,
 	)
-	return fmt.Sprintf("%s://%s%s", scheme, hostname, repl.Replace(ApiUrlDevicesDownloadConfig))
+	return scheme + "://" + hostname + repl.Replace(ApiUrlDevicesDownloadConfig)
 }

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -61,7 +61,7 @@ const (
 	ApiUrlDevicesDeploymentsNext  = ApiUrlDevices + "/device/deployments/next"
 	ApiUrlDevicesDeploymentStatus = ApiUrlDevices + "/device/deployments/:id/status"
 	ApiUrlDevicesDeploymentsLog   = ApiUrlDevices + "/device/deployments/:id/log"
-	ApiUrlDevicesDownloadConfig   = ApiUrlDevices + "/configuration/download/:deployment_id/:device_type/:device_id"
+	ApiUrlDevicesDownloadConfig   = ApiUrlDevices + "/download/configuration/:deployment_id/:device_type/:device_id"
 
 	ApiUrlInternalAlive                          = ApiUrlInternal + "/alive"
 	ApiUrlInternalHealth                         = ApiUrlInternal + "/health"

--- a/app/app.go
+++ b/app/app.go
@@ -1142,6 +1142,18 @@ func (d *Deployments) GetDeploymentForDeviceWithCurrent(ctx context.Context, dev
 
 		return nil, nil
 	}
+	if deployment.Type == model.DeploymentTypeConfiguration {
+		// There's nothing more we need to do, the link must be filled
+		// in by the API layer.
+		return &model.DeploymentInstructions{
+			ID: deployment.Id,
+			Artifact: model.ArtifactDeploymentInstructions{
+				ArtifactName:          deployment.ArtifactName,
+				DeviceTypesCompatible: []string{installed.DeviceType},
+			},
+			Type: model.DeploymentTypeConfiguration,
+		}, nil
+	}
 
 	// assign artifact only if the artifact was not assigned previously or the device type has changed
 	if deviceDeployment.Image == nil ||

--- a/app/app.go
+++ b/app/app.go
@@ -45,8 +45,8 @@ import (
 const (
 	ArtifactContentType              = "application/vnd.mender-artifact"
 	ArtifactConfigureType            = "mender-configure"
-	ArtifactConfigureProvides        = "module-image.mender-configure.version"
-	ArtifactConfigureProvidesCleared = "module-image.mender-configure.*"
+	ArtifactConfigureProvides        = "data-partition.mender-configure.version"
+	ArtifactConfigureProvidesCleared = "data-partition.mender-configure.*"
 
 	DefaultUpdateDownloadLinkExpire  = 24 * time.Hour
 	DefaultImageGenerationLinkExpire = 7 * 24 * time.Hour

--- a/app/images_test.go
+++ b/app/images_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -18,9 +18,11 @@ package mocks
 
 import (
 	context "context"
+	io "io"
+
+	mock "github.com/stretchr/testify/mock"
 
 	model "github.com/mendersoftware/deployments/model"
-	mock "github.com/stretchr/testify/mock"
 
 	time "time"
 )
@@ -172,6 +174,29 @@ func (_m *App) EditImage(ctx context.Context, id string, constructorData *model.
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string, *model.ImageMeta) error); ok {
 		r1 = rf(ctx, id, constructorData)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GenerateConfigurationImage provides a mock function with given fields: ctx, deviceType, deploymentID
+func (_m *App) GenerateConfigurationImage(ctx context.Context, deviceType string, deploymentID string) (io.Reader, error) {
+	ret := _m.Called(ctx, deviceType, deploymentID)
+
+	var r0 io.Reader
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) io.Reader); ok {
+		r0 = rf(ctx, deviceType, deploymentID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(io.Reader)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, deviceType, deploymentID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -204,12 +204,12 @@ presign:
   # URL format [url_scheme]://[(X-Forwarded-Host|url_hostname)[<path(generated)>]
 
   # Presign hostname
-  # This is the fallback hostname (to the gateway proxy) used for generating
-  # signed download URLs, the value is only used if the proxy does not forward
-  # X-Forwarded-Host.
-  # Defaults to: localhost
+  # This is the hostname (to the gateway proxy) used for generating
+  # signed download URLs. If left empty, the service will attempt to use
+  # X-Forwarded-Host forwarded by the proxy.
+  # Defaults to: "" (use X-Forwarded-Host)
   # Overwrite with environment variable: DEPLOYMENTS_PRESIGN_URL_HOSTNAME
-  url_hostname: "localhost"
+  url_hostname: ""
   # Presign URL scheme
   # This value is used as the url scheme for generating signed URLs.
   # Defaults to: https

--- a/config.yaml
+++ b/config.yaml
@@ -177,3 +177,6 @@ aws:
     #     key: ACCESS_KEY
     #     secret: SECRET_KEY
     #     token: TOKEN
+
+presign_secret_base64: "qF4/MZzQmHTJ+nrlr26b3g=="
+presign_expire_seconds: 900

--- a/config.yaml
+++ b/config.yaml
@@ -191,9 +191,9 @@ presign:
   # The secret used for signing URLs. For HMAC256 the value must be a valid
   # base64 encoded secret, for public key signatures it must be a path to a
   # private key. (Public key signatures are not yet supported).
-  # Defaults to: qF4/MZzQmHTJ+nrlr26b3g==
+  # Defaults to: "" (randomly geneated string of bytes)
   # Override with environment variable: DEPLOYMENTS_PRESIGN_SECRET
-  secret: "qF4/MZzQmHTJ+nrlr26b3g=="
+  secret: ""
 
   # Link expiry duration
   # Number of second a presigned URL is valid

--- a/config.yaml
+++ b/config.yaml
@@ -178,5 +178,41 @@ aws:
     #     secret: SECRET_KEY
     #     token: TOKEN
 
-presign_secret_base64: "qF4/MZzQmHTJ+nrlr26b3g=="
-presign_expire_seconds: 900
+presign:
+  # Presign algorithm
+  # Signature algorithm used for generating URL signature for signed URLs.
+  # Currently only HMAC256 is supported and this configuration is ignored.
+  # enum: ["HMAC256"]
+  # Defaults to: HMAC256
+  # Override with environment variable: DEPLOYMENTS_PRESIGN_ALGORITHM
+  algorithm: "HMAC256"
+
+  # Presign secret
+  # The secret used for signing URLs. For HMAC256 the value must be a valid
+  # base64 encoded secret, for public key signatures it must be a path to a
+  # private key. (Public key signatures are not yet supported).
+  # Defaults to: qF4/MZzQmHTJ+nrlr26b3g==
+  # Override with environment variable: DEPLOYMENTS_PRESIGN_SECRET
+  secret: "qF4/MZzQmHTJ+nrlr26b3g=="
+
+  # Link expiry duration
+  # Number of second a presigned URL is valid
+  # Defaults to: 900 (15 minutes)
+  # Override with environment variable: DEPLOYMENTS_PRESIGN_EXPIRE_SECONDS
+  expire_seconds: 900
+
+  # URL format [url_scheme]://[(X-Forwarded-Host|url_hostname)[<path(generated)>]
+
+  # Presign hostname
+  # This is the fallback hostname (to the gateway proxy) used for generating
+  # signed download URLs, the value is only used if the proxy does not forward
+  # X-Forwarded-Host.
+  # Defaults to: localhost
+  # Overwrite with environment variable: DEPLOYMENTS_PRESIGN_URL_HOSTNAME
+  url_hostname: "localhost"
+  # Presign URL scheme
+  # This value is used as the url scheme for generating signed URLs.
+  # Defaults to: https
+  # Overwrite with environment variable: DEPLOYMENTS_PRESIGN_URL_SCHEME
+  url_scheme: "https"
+

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/config/config.go
+++ b/config/config.go
@@ -74,11 +74,32 @@ const (
 	SettingInventoryTimeout        = "inventory_timeout"
 	SettingInventoryTimeoutDefault = 10
 
-	SettingPresignSecretBase64        = "presign_secret_base64"
-	SettingPresignSecretBase64Default = "qF4/MZzQmHTJ+nrlr26b3g=="
+	// SettingPresignAlgorithm sets the algorithm used for signing
+	// downloadable URLs. This option is currently ignored.
+	SettingPresignAlgorithm        = "presign.algorithm"
+	SettingPresignAlgorithmDefault = "HMAC256"
 
-	SettingPresignExpireSeconds        = "presign_expire_seconds"
+	// SettingPresignSecret sets the secret for generating signed url.
+	// For HMAC type of algorithms the value must be a base64 encoded
+	// secret. For public key signatures, the value must be a path to
+	// the private key (not yet supported).
+	SettingPresignSecret        = "presign.secret"
+	SettingPresignSecretDefault = "qF4/MZzQmHTJ+nrlr26b3g=="
+
+	// SettingPresignExpireSeconds sets the amount of seconds it takes for
+	// the signed URL to expire.
+	SettingPresignExpireSeconds        = "presign.expire_seconds"
 	SettingPresignExpireSecondsDefault = 900
+
+	// SettingPresignHost sets the fallback URL hostname (pointing to the
+	// gateway) in case the gateway does not send X-Forwarded-Host header.
+	SettingPresignHost        = "presign.url_hostname"
+	SettingPresignHostDefault = "localhost"
+
+	// SettingPresignURLScheme sets the URL scheme used for generating the
+	// pre-signed url.
+	SettingPresignScheme        = "presign.url_scheme"
+	SettingPresignSchemeDefault = "https"
 )
 
 // ValidateAwsAuth validates configuration of SettingsAwsAuth section if provided.
@@ -144,7 +165,10 @@ var (
 		{Key: SettingsAwsTagArtifact, Value: SettingsAwsTagArtifactDefault},
 		{Key: SettingInventoryAddr, Value: SettingInventoryAddrDefault},
 		{Key: SettingInventoryTimeout, Value: SettingInventoryTimeoutDefault},
-		{Key: SettingPresignSecretBase64, Value: SettingPresignSecretBase64},
+		{Key: SettingPresignAlgorithm, Value: SettingPresignAlgorithmDefault},
+		{Key: SettingPresignSecret, Value: SettingPresignSecret},
 		{Key: SettingPresignExpireSeconds, Value: SettingPresignExpireSecondsDefault},
+		{Key: SettingPresignHost, Value: SettingPresignHostDefault},
+		{Key: SettingPresignScheme, Value: SettingPresignSchemeDefault},
 	}
 )

--- a/config/config.go
+++ b/config/config.go
@@ -91,10 +91,12 @@ const (
 	SettingPresignExpireSeconds        = "presign.expire_seconds"
 	SettingPresignExpireSecondsDefault = 900
 
-	// SettingPresignHost sets the fallback URL hostname (pointing to the
-	// gateway) in case the gateway does not send X-Forwarded-Host header.
+	// SettingPresignHost sets the URL hostname (pointing to the gateway)
+	// for the generated URL. If the configuration option is left blank
+	// (default), it will try to use the X-Forwarded-Host header forwarded
+	// by the proxy.
 	SettingPresignHost        = "presign.url_hostname"
-	SettingPresignHostDefault = "localhost"
+	SettingPresignHostDefault = ""
 
 	// SettingPresignURLScheme sets the URL scheme used for generating the
 	// pre-signed url.

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,12 @@ const (
 
 	SettingInventoryTimeout        = "inventory_timeout"
 	SettingInventoryTimeoutDefault = 10
+
+	SettingPresignSecretBase64        = "presign_secret_base64"
+	SettingPresignSecretBase64Default = "qF4/MZzQmHTJ+nrlr26b3g=="
+
+	SettingPresignExpireSeconds        = "presign_expire_seconds"
+	SettingPresignExpireSecondsDefault = 900
 )
 
 // ValidateAwsAuth validates configuration of SettingsAwsAuth section if provided.
@@ -138,5 +144,7 @@ var (
 		{Key: SettingsAwsTagArtifact, Value: SettingsAwsTagArtifactDefault},
 		{Key: SettingInventoryAddr, Value: SettingInventoryAddrDefault},
 		{Key: SettingInventoryTimeout, Value: SettingInventoryTimeoutDefault},
+		{Key: SettingPresignSecretBase64, Value: SettingPresignSecretBase64},
+		{Key: SettingPresignExpireSeconds, Value: SettingPresignExpireSecondsDefault},
 	}
 )

--- a/config/config.go
+++ b/config/config.go
@@ -84,7 +84,7 @@ const (
 	// secret. For public key signatures, the value must be a path to
 	// the private key (not yet supported).
 	SettingPresignSecret        = "presign.secret"
-	SettingPresignSecretDefault = "qF4/MZzQmHTJ+nrlr26b3g=="
+	SettingPresignSecretDefault = ""
 
 	// SettingPresignExpireSeconds sets the amount of seconds it takes for
 	// the signed URL to expire.
@@ -166,7 +166,7 @@ var (
 		{Key: SettingInventoryAddr, Value: SettingInventoryAddrDefault},
 		{Key: SettingInventoryTimeout, Value: SettingInventoryTimeoutDefault},
 		{Key: SettingPresignAlgorithm, Value: SettingPresignAlgorithmDefault},
-		{Key: SettingPresignSecret, Value: SettingPresignSecret},
+		{Key: SettingPresignSecret, Value: SettingPresignSecretDefault},
 		{Key: SettingPresignExpireSeconds, Value: SettingPresignExpireSecondsDefault},
 		{Key: SettingPresignHost, Value: SettingPresignHostDefault},
 		{Key: SettingPresignScheme, Value: SettingPresignSchemeDefault},

--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -204,7 +204,8 @@ paths:
         200:
           description: Successful response
           schema:
-            type: binary
+            type: string
+            format: binary
             description: Artifact file
         400:
           $ref: "#/responses/InvalidRequestError"

--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -159,6 +159,60 @@ paths:
         500:
           $ref: "#/responses/InternalServerError"
 
+  /configuration/download/{deployment_id}/{device_type}/{device_id}:
+    get:
+      operationId: Fetch Configuration
+      tags:
+        - Device API
+      security: []
+      summary: |
+        Internally generated download link for deploying device configurations.
+        All parameters are generated internally when fetching a configuration deployment.
+      parameters:
+        - name: deployment_id
+          in: path
+          description: Deployment UUID
+          type: string
+          required: true
+        - name: device_type
+          in: path
+          description: Device type of the calling device
+          type: string
+          required: true
+        - name: device_id
+          in: path
+          description: Device UUID
+          type: string
+          required: true
+        - name: x-men-expire
+          in: query
+          description: Time of link expire
+          type: string
+          format: date-time
+          required: true
+        - name: x-men-signature
+          in: query
+          description: Signature of the URL link
+          type: string
+          required: true
+        - name: tenant_id
+          in: query
+          description: Device tenant ID
+          type: string
+          required: false
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: binary
+            description: Artifact file
+        400:
+          $ref: "#/responses/InvalidRequestError"
+        403:
+          description: The download link has expired or the signature is invalid.
+        500:
+          $ref: "#/responses/InternalServerError"
+
 definitions:
   Error:
     description: Error descriptor.

--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -159,7 +159,7 @@ paths:
         500:
           $ref: "#/responses/InternalServerError"
 
-  /configuration/download/{deployment_id}/{device_type}/{device_id}:
+  /download/configuration/{deployment_id}/{device_type}/{device_id}:
     get:
       operationId: Fetch Configuration
       tags:

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func doMain(args []string) {
 	app.Action = cmdServer
 	app.Before = func(args *cli.Context) error {
 
+		l := log.NewEmpty()
 		err := config.FromConfigFile(configPath, dconfig.Defaults)
 		if err != nil {
 			return cli.NewExitError(
@@ -90,6 +91,16 @@ func doMain(args []string) {
 		config.Config.SetEnvPrefix("DEPLOYMENTS")
 		config.Config.AutomaticEnv()
 		config.Config.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+		if config.Config.Get(dconfig.SettingPresignSecret) ==
+			dconfig.SettingPresignSecretDefault {
+			l.Warn("Using the default signature secret; THIS IS A POTENTIAL SECURITY ISSUE!")
+			l.Warnf(
+				"Please reconfigure the secret in '%s' or "+
+					"override with environment variable "+
+					"DEPLOYMENTS_PRESIGN_SECRET_BASE64",
+				args.String("config"),
+			)
+		}
 
 		return nil
 	}

--- a/model/deployment_instructions.go
+++ b/model/deployment_instructions.go
@@ -23,4 +23,5 @@ type ArtifactDeploymentInstructions struct {
 type DeploymentInstructions struct {
 	ID       string                         `json:"id"`
 	Artifact ArtifactDeploymentInstructions `json:"artifact"`
+	Type     DeploymentType                 `json:"-"`
 }

--- a/model/deployment_instructions.go
+++ b/model/deployment_instructions.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/model/signature.go
+++ b/model/signature.go
@@ -1,0 +1,112 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package model
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/pkg/errors"
+)
+
+const (
+	ParamExpire    = "x-men-expire"
+	ParamSignature = "x-men-signature"
+	ParamTenantID  = "tenant_id"
+)
+
+var ErrLinkExpired = errors.New("URL expired")
+
+type RequestSignature struct {
+	*http.Request
+	Secret []byte
+}
+
+func NewRequestSignature(req *http.Request, secret []byte) *RequestSignature {
+	return &RequestSignature{
+		Request: req,
+		Secret:  secret,
+	}
+}
+
+func (sig *RequestSignature) SetExpire(expire time.Time) {
+	q := sig.URL.Query()
+	q.Set(ParamExpire, expire.UTC().Format(time.RFC3339))
+}
+
+// Validate validates the request parameters - assumes that
+func (sig *RequestSignature) Validate() error {
+	q := sig.URL.Query()
+	if err := validation.Validate(q, validation.Map(
+		validation.Key(ParamExpire, validation.Required),
+		validation.Key(ParamSignature, validation.Required),
+	).AllowExtraKeys()); err != nil {
+		return err
+	}
+	ts, err := time.Parse(time.RFC3339, q.Get(ParamExpire))
+	if err != nil {
+		return errors.Errorf("parameter '%s' is not a valid timestamp", ParamExpire)
+	}
+	if time.Now().After(ts) {
+		return ErrLinkExpired
+	}
+	return nil
+}
+
+// PresignURL generates and assign the request signature parameter and returning
+// the resulting URL.
+func (sig *RequestSignature) PresignURL() string {
+	signature := sig.HMAC256()
+	signature64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	q := sig.URL.Query()
+	q.Set(ParamSignature, signature64)
+	sig.URL.RawQuery = q.Encode()
+	return sig.URL.String()
+}
+
+func (sig *RequestSignature) Bytes() []byte {
+	// Bytes returns the byte digest for the HMAC256
+	// The format is similar to s3 signed request with
+	// <Method>\n<Canonical URI>\n<Canonical parameters>\n[<Canonical headers>]\n
+	q := sig.URL.Query()
+	return []byte(fmt.Sprintf(
+		"%s\n%s\n%s=%s\n%s=%s\n",
+		sig.Method, sig.URL.Path,
+		ParamExpire, q.Get(ParamExpire),
+		ParamTenantID, q.Get(ParamTenantID),
+	))
+}
+
+// VerifyHMAC256 verifies the request signature with the parameter.
+func (sig *RequestSignature) VerifyHMAC256() bool {
+	//nolint:errcheck
+	q := sig.URL.Query()
+	sign, _ := base64.RawURLEncoding.
+		DecodeString(q.Get(ParamSignature))
+	return hmac.Equal(sig.HMAC256(), sign)
+}
+
+//nolint:errcheck
+func (sig *RequestSignature) HMAC256() []byte {
+	hash := hmac.New(sha256.New, sig.Secret)
+	hash.Write(sig.Bytes())
+	return hash.Sum(nil)
+}

--- a/model/signature.go
+++ b/model/signature.go
@@ -49,6 +49,7 @@ func NewRequestSignature(req *http.Request, secret []byte) *RequestSignature {
 func (sig *RequestSignature) SetExpire(expire time.Time) {
 	q := sig.URL.Query()
 	q.Set(ParamExpire, expire.UTC().Format(time.RFC3339))
+	sig.URL.RawQuery = q.Encode()
 }
 
 // Validate validates the request parameters - assumes that

--- a/model/signature.go
+++ b/model/signature.go
@@ -52,7 +52,8 @@ func (sig *RequestSignature) SetExpire(expire time.Time) {
 	sig.URL.RawQuery = q.Encode()
 }
 
-// Validate validates the request parameters - assumes that
+// Validate validates the request parameters - assumes that the signature is
+// already signed.
 func (sig *RequestSignature) Validate() error {
 	q := sig.URL.Query()
 	if err := validation.Validate(q, validation.Map(

--- a/model/signature_test.go
+++ b/model/signature_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestSignatureValidate(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Name string
+
+		Request *RequestSignature
+
+		Error error // Validation error
+	}{{
+		Name: "ok",
+
+		Request: func() *RequestSignature {
+			req, _ := http.NewRequest(http.MethodGet, "https://localhost", nil)
+			sig := NewRequestSignature(req, []byte("test"))
+			sig.SetExpire(time.Now().Add(time.Hour))
+			sig.PresignURL()
+			return sig
+		}(),
+	}, {
+		Name: "error, missing signature",
+
+		Request: func() *RequestSignature {
+			req, _ := http.NewRequest(http.MethodGet, "https://localhost", nil)
+			sig := NewRequestSignature(req, []byte("test"))
+			return sig
+		}(),
+		Error: errors.Errorf(
+			"%s: required key is missing; %s: required key is missing.",
+			ParamExpire, ParamSignature,
+		),
+	}, {
+		Name: "error, malformed timestamp",
+
+		Request: func() *RequestSignature {
+			req, _ := http.NewRequest(
+				http.MethodGet, fmt.Sprintf(
+					"https://localhost?%s=foobar&%s=barbaz",
+					ParamExpire, ParamSignature,
+				), nil,
+			)
+			sig := NewRequestSignature(req, []byte("test"))
+			return sig
+		}(),
+		Error: errors.Errorf(
+			"parameter '%s' is not a valid timestamp", ParamExpire,
+		),
+	}, {
+		Name: "error, timestamp expired",
+
+		Request: func() *RequestSignature {
+			req, _ := http.NewRequest(http.MethodGet, "https://localhost", nil)
+			sig := NewRequestSignature(req, []byte("test"))
+			sig.SetExpire(time.Now().Add(-time.Hour))
+			sig.PresignURL()
+			return sig
+		}(),
+		Error: ErrLinkExpired,
+	}}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.Request.Validate()
+			if tc.Error != nil {
+				assert.EqualError(t, err, tc.Error.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, tc.Request.VerifyHMAC256())
+			}
+		})
+	}
+}

--- a/vendor/github.com/mendersoftware/mender-artifact/artifact/stage/stage.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/artifact/stage/stage.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package stage
+
+// The stages the Artifact parser/writer is in
+const (
+	Version           = "Version"
+	Manifest          = "Manifest"
+	ManifestSignature = "Manifest signature"
+	ManifestAugment   = "Manifest augment"
+	Header            = "Header"
+	HeaderAugment     = "Header Augment"
+	Data              = "Payload"
+)

--- a/vendor/github.com/mendersoftware/mender-artifact/awriter/signer.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/awriter/signer.go
@@ -1,0 +1,130 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package awriter
+
+import (
+	"archive/tar"
+	"io"
+
+	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/pkg/errors"
+)
+
+var ErrAlreadyExistingSignature = errors.New("The Artifact is already signed, will not overwrite existing signature")
+var ErrManifestNotFound = errors.New("`manifest` not found. Corrupt Artifact?")
+
+// Special fast-track to just sign, nothing else. This skips all the expensive
+// and complicated repacking, and simply adds the manifest.sig file.
+func SignExisting(src io.Reader, dst io.Writer, key []byte, overwrite bool) error {
+	var foundManifest bool
+	rTar := tar.NewReader(src)
+	wTar := tar.NewWriter(dst)
+	for {
+		header, err := rTar.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return errors.Wrap(err, "Could not read tar header")
+		}
+
+		switch header.Name {
+		case "manifest":
+			err = signManifestAndOutputSignature(header, rTar, wTar, key)
+			if err != nil {
+				return err
+			}
+			foundManifest = true
+			continue
+		case "manifest.sig":
+			if overwrite {
+				continue
+			} else {
+				return ErrAlreadyExistingSignature
+			}
+		}
+
+		err = wTar.WriteHeader(header)
+		if err != nil {
+			return errors.Wrap(err, "Could not write tar header")
+		}
+
+		_, err = io.Copy(wTar, rTar)
+		if err != nil {
+			return errors.Wrap(err, "Failed to copy tar body")
+		}
+	}
+
+	err := wTar.Close()
+	if err != nil {
+		return errors.Wrap(err, "Could not finalize tar archive")
+	}
+
+	if !foundManifest {
+		return ErrManifestNotFound
+	}
+
+	return nil
+}
+
+func signManifestAndOutputSignature(header *tar.Header, src *tar.Reader, dst *tar.Writer, key []byte) error {
+	signer := artifact.NewSigner(key)
+	buf := make([]byte, header.Size)
+	read, err := src.Read(buf)
+	if err != nil && err != io.EOF {
+		return errors.Wrap(err, "Could not read manifest")
+	} else if int64(read) != header.Size {
+		return errors.New("Unexpected mismatch between header size and read size")
+	}
+
+	err = dst.WriteHeader(header)
+	if err != nil {
+		return errors.Wrap(err, "Could not write manifest header")
+	}
+	written, err := dst.Write(buf)
+	if err != nil {
+		return errors.Wrap(err, "Could not write manifest")
+	} else if written != read {
+		return errors.New("Could not write entire manifest")
+	}
+
+	signedBuf, err := signer.Sign(buf)
+	if err != nil {
+		return errors.Wrap(err, "Could not sign manifest")
+	}
+
+	signedHeader := &tar.Header{
+		Name: "manifest.sig",
+		Size: int64(len(signedBuf)),
+		Mode: 0644,
+	}
+
+	err = dst.WriteHeader(signedHeader)
+	if err != nil {
+		return errors.Wrap(err, "Could not write signature header")
+	}
+	written, err = dst.Write(signedBuf)
+	if err != nil {
+		return errors.Wrap(err, "Could not write signature")
+	} else if written != len(signedBuf) {
+		return errors.New("Could not write entire manifest.sig")
+	}
+
+	read, err = src.Read(buf)
+	if err != io.EOF || read != 0 {
+		return errors.New("File bigger than its header size")
+	}
+
+	return nil
+}

--- a/vendor/github.com/mendersoftware/mender-artifact/awriter/writer.go
+++ b/vendor/github.com/mendersoftware/mender-artifact/awriter/writer.go
@@ -1,0 +1,575 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package awriter
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/mendersoftware/mender-artifact/artifact"
+	"github.com/mendersoftware/mender-artifact/artifact/stage"
+	"github.com/mendersoftware/mender-artifact/handlers"
+	"github.com/pkg/errors"
+)
+
+type ProgressWriter interface {
+	Wrap(io.WriteCloser) io.Writer
+	Reset(size int64, filename string, payloadNr int)
+	Finish()
+	io.Writer
+}
+
+// Writer provides on the fly writing of artifacts metadata file used by
+// the Mender client and the server.
+type Writer struct {
+	w              io.Writer // underlying writer
+	signer         artifact.Signer
+	c              artifact.Compressor
+	State          chan string    // Report progress
+	ProgressWriter ProgressWriter // Report progress whilst writing
+}
+
+func NewWriter(w io.Writer, c artifact.Compressor) *Writer {
+	return &Writer{
+		w:     w,
+		c:     c,
+		State: make(chan string, 10),
+	}
+}
+
+func NewWriterSigned(w io.Writer, c artifact.Compressor, manifestChecksumStore artifact.Signer) *Writer {
+	nw := NewWriter(w, c)
+	nw.signer = manifestChecksumStore
+	return nw
+}
+
+type Updates struct {
+	// Both of these are indexed the same, so Augment at index X corresponds
+	// to Update at index X.
+	Updates  []handlers.Composer
+	Augments []handlers.Composer
+}
+
+// Iterate through all data files inside `upd` and calculate checksums.
+func calcDataHash(manifestChecksumStore *artifact.ChecksumStore, upd *Updates, augmented bool) error {
+	var updates []handlers.Composer
+	if augmented {
+		updates = upd.Augments
+	} else {
+		updates = upd.Updates
+	}
+	for i, u := range updates {
+		var files [](*handlers.DataFile)
+		if augmented {
+			if u == nil {
+				// Can happen if there is no augmented part.
+				continue
+			}
+			files = u.GetUpdateAugmentFiles()
+		} else {
+			files = u.GetUpdateFiles()
+		}
+		for _, f := range files {
+			ch := artifact.NewWriterChecksum(ioutil.Discard)
+			df, err := os.Open(f.Name)
+			if err != nil {
+				return errors.Wrapf(err, "writer: can not open data file: %s", f.Name)
+			}
+			defer df.Close()
+			if _, err := io.Copy(ch, df); err != nil {
+				return errors.Wrapf(err, "writer: can not calculate checksum: %s", f.Name)
+			}
+			sum := ch.Checksum()
+			f.Checksum = sum
+			manifestChecksumStore.Add(filepath.Join(artifact.UpdatePath(i), filepath.Base(f.Name)), sum)
+		}
+	}
+	return nil
+}
+
+// writeTempHeader can write both the standard and the augmented header
+func writeTempHeader(c artifact.Compressor, manifestChecksumStore *artifact.ChecksumStore,
+	name string, args *WriteArtifactArgs, augmented bool) (*os.File, error) {
+
+	// create temporary header file
+	f, err := ioutil.TempFile("", name)
+	if err != nil {
+		return nil, errors.New("writer: can not create temporary header file")
+	}
+
+	ch := artifact.NewWriterChecksum(f)
+	// use function to make sure to close gz and tar before
+	// calculating checksum
+	err = func() error {
+		gz, err := c.NewWriter(ch)
+		if err != nil {
+			return errors.Wrapf(err, "writer: can not open compressor")
+		}
+		defer gz.Close()
+
+		htw := tar.NewWriter(gz)
+		defer htw.Close()
+
+		// Header differs in version 3 from version 2.
+		if err = writeHeader(htw, args, augmented); err != nil {
+			return errors.Wrapf(err, "writer: error writing header")
+		}
+		return nil
+	}()
+
+	if err != nil {
+		os.Remove(f.Name())
+		return nil, err
+	}
+	fullName := fmt.Sprintf("%s.tar%s", name, c.GetFileExtension())
+	manifestChecksumStore.Add(fullName, ch.Checksum())
+
+	return f, nil
+}
+
+func WriteSignature(tw *tar.Writer, message []byte,
+	signer artifact.Signer) error {
+	if signer == nil {
+		return nil
+	}
+
+	sig, err := signer.Sign(message)
+	if err != nil {
+		return errors.Wrap(err, "writer: can not sign artifact")
+	}
+	sw := artifact.NewTarWriterStream(tw)
+	if err := sw.Write(sig, "manifest.sig"); err != nil {
+		return errors.Wrap(err, "writer: can not tar signature")
+	}
+	return nil
+}
+
+type WriteArtifactArgs struct {
+	Format            string
+	Version           int
+	Devices           []string
+	Name              string
+	Updates           *Updates
+	Scripts           *artifact.Scripts
+	Depends           *artifact.ArtifactDepends
+	Provides          *artifact.ArtifactProvides
+	TypeInfoV3        *artifact.TypeInfoV3
+	MetaData          map[string]interface{} // Generic JSON
+	AugmentTypeInfoV3 *artifact.TypeInfoV3
+	AugmentMetaData   map[string]interface{} // Generic JSON
+}
+
+func (aw *Writer) WriteArtifact(args *WriteArtifactArgs) (err error) {
+
+	if args.Version == 1 {
+		return errors.New("writer: The Mender-Artifact version 1 is outdated. Refusing to create artifact.")
+	}
+
+	if !(args.Version == 2 || args.Version == 3) {
+		return errors.New("Unsupported artifact version")
+	}
+
+	if args.Version == 3 {
+		return aw.writeArtifactV3(args)
+	}
+
+	return aw.writeArtifactV2(args)
+}
+
+func (aw *Writer) writeArtifactV2(args *WriteArtifactArgs) error {
+
+	// mender archive writer
+	tw := tar.NewWriter(aw.w)
+	defer tw.Close()
+
+	aw.State <- stage.Version
+	// write version file
+	inf, err := artifact.ToStream(&artifact.Info{Version: args.Version, Format: args.Format})
+	if err != nil {
+		return err
+	}
+	sa := artifact.NewTarWriterStream(tw)
+	if err := sa.Write(inf, "version"); err != nil {
+		return errors.Wrapf(err, "writer: can not write version tar header")
+	}
+
+	aw.State <- stage.Manifest
+	manifestChecksumStore := artifact.NewChecksumStore()
+	// calculate checksums of all data files
+	// we need this regardless of which artifact version we are writing
+	if err := calcDataHash(manifestChecksumStore, args.Updates, false); err != nil {
+		return err
+	}
+	tmpHdr, err := writeTempHeader(aw.c, manifestChecksumStore, "header", args, false)
+
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpHdr.Name())
+
+	if err = writeManifestVersion(args.Version, aw.signer, tw, manifestChecksumStore, nil, inf); err != nil {
+		return errors.Wrap(err, "WriteArtifact")
+	}
+
+	// write header
+	aw.State <- stage.Header
+	if _, err := tmpHdr.Seek(0, 0); err != nil {
+		return errors.Wrapf(err, "writer: error preparing tmp header for writing")
+	}
+	fw := artifact.NewTarWriterFile(tw)
+	if err := fw.Write(tmpHdr, "header.tar"+aw.c.GetFileExtension()); err != nil {
+		return errors.Wrapf(err, "writer: can not tar header")
+	}
+
+	// write data files
+	aw.State <- stage.Data
+	return writeData(tw, aw.c, args.Updates, aw.ProgressWriter)
+}
+
+func (aw *Writer) writeArtifactV3(args *WriteArtifactArgs) (err error) {
+	tw := tar.NewWriter(aw.w)
+	defer tw.Close()
+
+	aw.State <- stage.Version
+	////////////////////////
+	// write version file //
+	////////////////////////
+	inf, err := artifact.ToStream(&artifact.Info{Version: args.Version, Format: args.Format})
+	if err != nil {
+		return err
+	}
+	sa := artifact.NewTarWriterStream(tw)
+	if err := sa.Write(inf, "version"); err != nil {
+		return errors.Wrapf(err, "writer: can not write version tar header")
+	}
+
+	////////////////////////////
+	// Write manifest         //
+	// Write manifest.sig     //
+	// Write manifest-augment //
+	////////////////////////////
+	aw.State <- stage.Manifest
+	augmentedDataPresent := (len(args.Updates.Augments) > 0)
+
+	// Holds the checksum for the update, and 'header.tar.gz', and the 'version' file.
+	manifestChecksumStore := artifact.NewChecksumStore()
+
+	// Holds the checksum for 'header-augment.tar.gz'.
+	augManifestChecksumStore := artifact.NewChecksumStore()
+	aw.State <- stage.ManifestSignature
+	if err := calcDataHash(manifestChecksumStore, args.Updates, false); err != nil {
+		return err
+	}
+	if augmentedDataPresent {
+		if err := calcDataHash(augManifestChecksumStore, args.Updates, true); err != nil {
+			return err
+		}
+	}
+	// The header in version 3 will have the original rootfs-checksum in type-info!
+	tmpHdr, err := writeTempHeader(aw.c, manifestChecksumStore, "header", args, false)
+	if err != nil {
+		return errors.Wrap(err, "writeArtifactV3: writing header")
+	}
+	defer os.Remove(tmpHdr.Name())
+
+	var tmpAugHdr *os.File
+	if augmentedDataPresent {
+		tmpAugHdr, err = writeTempHeader(aw.c, augManifestChecksumStore, "header-augment", args, true)
+		if err != nil {
+			return errors.Wrap(err, "writeArtifactV3: writing augmented header")
+		}
+		defer os.Remove(tmpAugHdr.Name())
+	}
+
+	if err = writeManifestVersion(args.Version, aw.signer, tw, manifestChecksumStore, augManifestChecksumStore, inf); err != nil {
+		return errors.Wrap(err, "WriteArtifact")
+	}
+
+	////////////////////
+	// Write header   //
+	////////////////////
+	aw.State <- stage.Header
+	if _, err := tmpHdr.Seek(0, 0); err != nil {
+		return errors.Wrapf(err, "writer: error preparing tmp header for writing")
+	}
+	fw := artifact.NewTarWriterFile(tw)
+	if err := fw.Write(tmpHdr, "header.tar"+aw.c.GetFileExtension()); err != nil {
+		return errors.Wrapf(err, "writer: can not tar header")
+	}
+
+	/////////////////////////////
+	// Write augmented-header  //
+	/////////////////////////////
+	if augmentedDataPresent {
+		aw.State <- stage.HeaderAugment
+		if _, err := tmpAugHdr.Seek(0, 0); err != nil {
+			return errors.Wrapf(err, "writer: error preparing tmp augment-header for writing")
+		}
+		fw = artifact.NewTarWriterFile(tw)
+		if err := fw.Write(tmpAugHdr, "header-augment.tar"+aw.c.GetFileExtension()); err != nil {
+			return errors.Wrapf(err, "writer: can not tar augmented-header")
+		}
+	}
+
+	//////////////////////////
+	// Write the datafiles  //
+	//////////////////////////
+	aw.State <- stage.Data
+	return writeData(tw, aw.c, args.Updates, aw.ProgressWriter)
+}
+
+// writeArtifactVersion writes version specific artifact records.
+func writeManifestVersion(version int, signer artifact.Signer, tw *tar.Writer, manifestChecksumStore, augmanChecksumStore *artifact.ChecksumStore, artifactInfoStream []byte) error {
+	switch version {
+	case 2:
+		// add checksum of `version`
+		ch := artifact.NewWriterChecksum(ioutil.Discard)
+		ch.Write(artifactInfoStream)
+		manifestChecksumStore.Add("version", ch.Checksum())
+		// write `manifest` file
+		sw := artifact.NewTarWriterStream(tw)
+		if err := sw.Write(manifestChecksumStore.GetRaw(), "manifest"); err != nil {
+			return errors.Wrapf(err, "writer: can not write manifest stream")
+		}
+		// write signature
+		if err := WriteSignature(tw, manifestChecksumStore.GetRaw(), signer); err != nil {
+			return err
+		}
+	case 3:
+		// Add checksum of `version`.
+		ch := artifact.NewWriterChecksum(ioutil.Discard)
+		ch.Write(artifactInfoStream)
+		manifestChecksumStore.Add("version", ch.Checksum())
+		// Write `manifest` file.
+		sw := artifact.NewTarWriterStream(tw)
+		if err := sw.Write(manifestChecksumStore.GetRaw(), "manifest"); err != nil {
+			return errors.Wrapf(err, "writer: can not write manifest stream")
+		}
+		// Write signature.
+		if err := WriteSignature(tw, manifestChecksumStore.GetRaw(), signer); err != nil {
+			return err
+		}
+		// Write the augmented manifest, if any.
+		if len(augmanChecksumStore.GetRaw()) > 0 {
+			sw = artifact.NewTarWriterStream(tw)
+			if err := sw.Write(augmanChecksumStore.GetRaw(), "manifest-augment"); err != nil {
+				return errors.Wrapf(err, "writer: can not write manifest stream")
+			}
+		}
+	default:
+		return fmt.Errorf("writer: unsupported artifact version: %d", version)
+	}
+	return nil
+}
+
+func writeScripts(tw *tar.Writer, scr *artifact.Scripts) error {
+	sw := artifact.NewTarWriterFile(tw)
+	for _, script := range scr.Get() {
+		f, err := os.Open(script)
+		if err != nil {
+			return errors.Wrapf(err, "writer: can not open script file: %s", script)
+		}
+		defer f.Close()
+
+		if err :=
+			sw.Write(f, filepath.Join("scripts", filepath.Base(script))); err != nil {
+			return errors.Wrapf(err, "writer: can not store script: %s", script)
+		}
+	}
+	return nil
+}
+
+func extractUpdateTypes(updates []handlers.Composer) []artifact.UpdateType {
+	u := []artifact.UpdateType{}
+	for _, upd := range updates {
+		u = append(u, artifact.UpdateType{upd.GetUpdateType()})
+	}
+	return u
+}
+
+func writeHeader(tarWriter *tar.Writer, args *WriteArtifactArgs, augmented bool) error {
+	var composers []handlers.Composer
+	if augmented {
+		composers = args.Updates.Augments
+	} else {
+		composers = args.Updates.Updates
+	}
+	if len(composers) == 0 {
+		return errors.New("writeHeader: No Payloads added")
+	}
+
+	// store header info
+	var hInfo artifact.WriteValidator
+	upds := extractUpdateTypes(composers)
+	switch args.Version {
+	case 1, 2:
+		hInfo = artifact.NewHeaderInfo(args.Name, upds, args.Devices)
+	case 3:
+		hInfo = artifact.NewHeaderInfoV3(upds, args.Provides, args.Depends)
+	}
+
+	sa := artifact.NewTarWriterStream(tarWriter)
+	stream, err := artifact.ToStream(hInfo)
+	if err != nil {
+		return errors.Wrap(err, "writeHeader")
+	}
+	if err := sa.Write(stream, "header-info"); err != nil {
+		return errors.New("writer: can not store header-info")
+	}
+
+	// write scripts
+	if !augmented && args.Scripts != nil {
+		if err := writeScripts(tarWriter, args.Scripts); err != nil {
+			return err
+		}
+	}
+
+	for i, upd := range composers {
+		// TODO: We only have one `args` variable here, so making more
+		// than one update is kind of useless. Should probably be made
+		// into a list as well.
+		composeHeaderArgs := handlers.ComposeHeaderArgs{
+			TarWriter: tarWriter,
+			No:        i,
+			Version:   args.Version,
+			Augmented: augmented,
+		}
+		if augmented {
+			composeHeaderArgs.TypeInfoV3 = args.AugmentTypeInfoV3
+			composeHeaderArgs.MetaData = args.AugmentMetaData
+		} else {
+			composeHeaderArgs.TypeInfoV3 = args.TypeInfoV3
+			composeHeaderArgs.MetaData = args.MetaData
+		}
+		if err := upd.ComposeHeader(&composeHeaderArgs); err != nil {
+			return errors.Wrapf(err, "writer: error composing header")
+		}
+	}
+	return nil
+}
+
+func writeData(tw *tar.Writer, comp artifact.Compressor, updates *Updates, pw ProgressWriter) error {
+	for i, upd := range updates.Updates {
+		var augment handlers.Composer = nil
+		if i < len(updates.Augments) {
+			augment = updates.Augments[i]
+		}
+		if err := writeOneDataTar(tw, comp, i, upd, augment, pw); err != nil {
+			return errors.Wrapf(err, "writer: error writing data files")
+		}
+	}
+	return nil
+}
+
+func writeOneDataTar(tw *tar.Writer, comp artifact.Compressor, no int,
+	baseUpdate, augmentUpdate handlers.Composer, pw ProgressWriter) error {
+
+	f, ferr := ioutil.TempFile("", "data")
+	if ferr != nil {
+		return errors.New("Payload: can not create temporary data file")
+	}
+	defer os.Remove(f.Name())
+
+	err := func() error {
+		gz, err := comp.NewWriter(f)
+		if err != nil {
+			return errors.Wrap(err, "Could not open compressor")
+		}
+		defer gz.Close()
+
+		var w io.Writer
+		if pw != nil {
+			w = pw.Wrap(gz)
+		} else {
+			w = gz
+		}
+		tarw := tar.NewWriter(w)
+		defer tarw.Close()
+
+		for i, file := range baseUpdate.GetUpdateFiles() {
+			fi, err := os.Stat(file.Name)
+			if err != nil {
+				return err
+			}
+			if pw != nil {
+				pw.Reset(fi.Size(), file.Name, i)
+			}
+			err = writeOneDataFile(tarw, file)
+			if err != nil {
+				return err
+			}
+			if pw != nil {
+				pw.Finish()
+			}
+		}
+		if augmentUpdate == nil {
+			return nil
+		}
+
+		for _, file := range augmentUpdate.GetUpdateAugmentFiles() {
+			err = writeOneDataFile(tarw, file)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}()
+
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.Seek(0, 0); err != nil {
+		return errors.Wrap(err, "Payload: can not reset file position")
+	}
+
+	dfw := artifact.NewTarWriterFile(tw)
+	if err = dfw.Write(f, artifact.UpdateDataPath(no)+comp.GetFileExtension()); err != nil {
+		return errors.Wrap(err, "Payload: can not write tar data header")
+	}
+	return nil
+}
+
+func writeOneDataFile(tarw *tar.Writer, file *handlers.DataFile) error {
+	matched, err := regexp.MatchString(`^[\w\-.,]+$`, filepath.Base(file.Name))
+
+	if err != nil {
+		return errors.Wrapf(err, "Payload: invalid regular expression pattern")
+	}
+
+	if !matched {
+		message := "Payload: data file " + file.Name + " contains forbidden characters"
+		info := "Only letters, digits and characters in the set \".,_-\" are allowed"
+		return fmt.Errorf("%s. %s", message, info)
+	}
+
+	df, err := os.Open(file.Name)
+	if err != nil {
+		return errors.Wrapf(err, "Payload: can not open data file: %s", file.Name)
+	}
+	fw := artifact.NewTarWriterFile(tarw)
+	if err := fw.Write(df, filepath.Base(file.Name)); err != nil {
+		df.Close()
+		return errors.Wrapf(err,
+			"Payload: can not write tar temp data header: %v", file)
+	}
+	df.Close()
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,6 +139,8 @@ github.com/mendersoftware/go-lib-micro/testing
 ## explicit
 github.com/mendersoftware/mender-artifact/areader
 github.com/mendersoftware/mender-artifact/artifact
+github.com/mendersoftware/mender-artifact/artifact/stage
+github.com/mendersoftware/mender-artifact/awriter
 github.com/mendersoftware/mender-artifact/handlers
 github.com/mendersoftware/mender-artifact/utils
 # github.com/mendersoftware/progressbar v0.0.2


### PR DESCRIPTION
This PR implements a new endpoint consuming signed expiring links generated by the /deployments/next API handler if the deployment is a configuration type deployment.

NOTE: This PR is still work in progress as there's missing some unit test coverage.