### PR TITLE
always return the type of the deployment with the deployment object

### DIFF
--- a/model/deployment.go
+++ b/model/deployment.go
@@ -203,10 +203,15 @@ func (d *Deployment) MarshalJSON() ([]byte, error) {
 
 	slim := struct {
 		*Alias
-		Devices []string `json:"devices,omitempty"`
+		Devices []string       `json:"devices,omitempty"`
+		Type    DeploymentType `json:"type,omitempty"`
 	}{
 		Alias:   (*Alias)(d),
 		Devices: nil,
+		Type:    d.Type,
+	}
+	if slim.Type == "" {
+		slim.Type = DeploymentTypeSoftware
 	}
 
 	return json.Marshal(&slim)

--- a/model/deployment_external_test.go
+++ b/model/deployment_external_test.go
@@ -228,7 +228,8 @@ func TestDeploymentMarshalJSON(t *testing.T) {
         "created":"` + dep.Created.Format(time.RFC3339Nano) + `",
         "device_count": 1337,
         "id":"14ddec54-30be-49bf-aa6b-97ce271d71f5",
-        "status": "inprogress"
+        "status": "inprogress",
+        "type": "software"
     }`
 
 	assert.JSONEq(t, expectedJSON, string(j))


### PR DESCRIPTION
It's possible that the deployment object in the database does not have
the "type" field. In this case, set the type to "software" when returning
the deployment object from the API.
