### PR TITLE
Increase the S3 upload timeout to 60 minutes

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -30,12 +30,14 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
 
+	"github.com/mendersoftware/go-lib-micro/config"
 	"github.com/mendersoftware/go-lib-micro/identity"
 	"github.com/mendersoftware/go-lib-micro/log"
 	"github.com/mendersoftware/go-lib-micro/requestlog"
 	"github.com/mendersoftware/go-lib-micro/rest_utils"
 
 	"github.com/mendersoftware/deployments/app"
+	dconfig "github.com/mendersoftware/deployments/config"
 	"github.com/mendersoftware/deployments/model"
 	"github.com/mendersoftware/deployments/store"
 )
@@ -298,7 +300,8 @@ func (d *DeploymentsApiHandlers) DownloadLink(w rest.ResponseWriter, r *rest.Req
 		return
 	}
 
-	link, err := d.app.DownloadLink(r.Context(), id, DefaultDownloadLinkExpire)
+	expireSeconds := config.Config.GetInt(dconfig.SettingsAwsDownloadExpireSeconds)
+	link, err := d.app.DownloadLink(r.Context(), id, time.Duration(expireSeconds)*time.Second)
 	if err != nil {
 		d.view.RenderInternalError(w, r, err, l)
 		return

--- a/config.yaml
+++ b/config.yaml
@@ -126,6 +126,17 @@ aws:
 
     # uri: example.com
 
+    # Download link expiry duration
+    # Number of second a presigned download URL is valid
+    # Defaults to: 900 (15 minutes)
+    # Override with environment variable: DEPLOYMENTS_AWS_DOWNLOAD_EXPIRE_SECONDS
+    download_expire_seconds: 900
+
+    # Download link expiry duration
+    # Number of second a presigned upload URL is valid
+    # Defaults to: 3600 (60 minutes)
+    # Override with environment variable: DEPLOYMENTS_AWS_UPLOAD_EXPIRE_SECONDS
+    upload_expire_seconds: 3600
 
     # Artifact Tagging
     # Defaults to: false

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,11 @@ const (
 	SettingsAwsTagArtifact            = SettingsAws + ".tag_artifact"
 	SettingsAwsTagArtifactDefault     = false
 
+	SettingsAwsDownloadExpireSeconds        = SettingsAws + ".download_expire_seconds"
+	SettingsAwsDownloadExpireSecondsDefault = 900
+	SettingsAwsUploadExpireSeconds          = SettingsAws + ".upload_expire_seconds"
+	SettingsAwsUploadExpireSecondsDefault   = 3600
+
 	SettingsAwsAuth      = SettingsAws + ".auth"
 	SettingAwsAuthKeyId  = SettingsAwsAuth + ".key"
 	SettingAwsAuthSecret = SettingsAwsAuth + ".secret"
@@ -159,6 +164,8 @@ var (
 		{Key: SettingAwsS3Region, Value: SettingAwsS3RegionDefault},
 		{Key: SettingAwsS3Bucket, Value: SettingAwsS3BucketDefault},
 		{Key: SettingAwsS3ForcePathStyle, Value: SettingAwsS3ForcePathStyleDefault},
+		{Key: SettingsAwsDownloadExpireSeconds, Value: SettingsAwsDownloadExpireSecondsDefault},
+		{Key: SettingsAwsUploadExpireSeconds, Value: SettingsAwsUploadExpireSecondsDefault},
 		{Key: SettingMongo, Value: SettingMongoDefault},
 		{Key: SettingDbSSL, Value: SettingDbSSLDefault},
 		{Key: SettingDbSSLSkipVerify, Value: SettingDbSSLSkipVerifyDefault},


### PR DESCRIPTION
The Mender API gateway, based on Traefik, doesn't buffer the file
uploads. This slows down the upload to S3 to match the upload speed of
the client; in turn, this requires an adjustement of the expiration time
of the S3 presigned upload URL to allow higher upload times.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>