### PR TITLE
MEN-3966: add support for AWS S3 Transfer Acceleration

### DIFF
--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -86,6 +86,7 @@ func SetupS3(c config.Reader) (s3.FileStorage, error) {
 			c.GetString(dconfig.SettingAwsURI),
 			c.GetBool(dconfig.SettingsAwsTagArtifact),
 			c.GetBool(dconfig.SettingAwsS3ForcePathStyle),
+			c.GetBool(dconfig.SettingAwsS3UseAccelerate),
 		)
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -216,8 +216,6 @@ func (d *Deployments) getFileStorage(ctx context.Context) (s3.FileStorage, error
 		uri := config.Config.GetString(dconfig.SettingAwsURI)
 		token := config.Config.GetString(dconfig.SettingAwsAuthToken)
 		tagArtifact := config.Config.GetBool(dconfig.SettingsAwsTagArtifact)
-		forcePathStype := config.Config.GetBool(dconfig.SettingAwsS3ForcePathStyle)
-
 		if settings.Region != "" {
 			region = settings.Region
 		}
@@ -242,7 +240,8 @@ func (d *Deployments) getFileStorage(ctx context.Context) (s3.FileStorage, error
 			token,
 			uri,
 			tagArtifact,
-			forcePathStype,
+			settings.ForcePathStyle,
+			settings.UseAccelerate,
 		)
 	}
 

--- a/config.yaml
+++ b/config.yaml
@@ -119,6 +119,12 @@ aws:
 
     # force_path_style: true
 
+    # Use S3 Transfer Acceleration
+    # Enable the S3 Transfer Acceleration for the operations that support it.
+    # Defaults to: false
+    # Overwrite with environment variable: DEPLOYMENTS_AWS_USE_ACCELERATE
+
+    # use_accelerate: false
 
     # S3 URI
     # Defaults to: none (s3.amazonaws.com)

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,8 @@ const (
 	SettingAwsS3BucketDefault         = "mender-artifact-storage"
 	SettingAwsS3ForcePathStyle        = SettingsAws + ".force_path_style"
 	SettingAwsS3ForcePathStyleDefault = true
+	SettingAwsS3UseAccelerate         = SettingsAws + ".use_accelerate"
+	SettingAwsS3UseAccelerateDefault  = false
 	SettingAwsURI                     = SettingsAws + ".uri"
 	SettingsAwsTagArtifact            = SettingsAws + ".tag_artifact"
 	SettingsAwsTagArtifactDefault     = false
@@ -164,6 +166,7 @@ var (
 		{Key: SettingAwsS3Region, Value: SettingAwsS3RegionDefault},
 		{Key: SettingAwsS3Bucket, Value: SettingAwsS3BucketDefault},
 		{Key: SettingAwsS3ForcePathStyle, Value: SettingAwsS3ForcePathStyleDefault},
+		{Key: SettingAwsS3UseAccelerate, Value: SettingAwsS3UseAccelerateDefault},
 		{Key: SettingsAwsDownloadExpireSeconds, Value: SettingsAwsDownloadExpireSecondsDefault},
 		{Key: SettingsAwsUploadExpireSeconds, Value: SettingsAwsUploadExpireSecondsDefault},
 		{Key: SettingMongo, Value: SettingMongoDefault},

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -438,8 +438,8 @@ definitions:
       region: us-east-1
       bucket: mender-artifacts-unique-bucket-name
       uri: example.com
-      key: AKIAQIHEV11XZJFVCNM4
-      secret: f2Ref4JU3eRqAFO23qpy5XOhcfTnzJivAcNO1lvn
+      key: <key>
+      secret: <secret>
       token: <token>
       force_path_style: false
       use_accelerate: false

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -423,6 +423,12 @@ definitions:
       token:
         type: string
         description: Token.
+      force_path_style:
+        type: boolean
+        description: Force S3 path-style instead of virtual-hosted style.
+      use_accelerate:
+        type: boolean
+        description: Enable S3 Transfer acceleration.
     required:
       - region
       - bucket
@@ -435,6 +441,8 @@ definitions:
       key: AKIAQIHEV11XZJFVCNM4
       secret: f2Ref4JU3eRqAFO23qpy5XOhcfTnzJivAcNO1lvn
       token: <token>
+      force_path_style: false
+      use_accelerate: false
   StorageUsage:
     description: Tenant account storage limit and storage usage.
     type: object

--- a/model/device_deployment.go
+++ b/model/device_deployment.go
@@ -17,7 +17,7 @@ package model
 import (
 	"time"
 
-	"github.com/go-ozzo/ozzo-validation/v4"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"

--- a/model/storage_settings.go
+++ b/model/storage_settings.go
@@ -23,12 +23,14 @@ import (
 )
 
 type StorageSettings struct {
-	Region string `json:"region" bson:"region"`
-	Bucket string `json:"bucket" bson:"bucket"`
-	Uri    string `json:"uri" bson:"uri"`
-	Key    string `json:"key" bson:"key"`
-	Secret string `json:"secret" bson:"secret"`
-	Token  string `json:"token" bson:"token"`
+	Region         string `json:"region" bson:"region"`
+	Bucket         string `json:"bucket" bson:"bucket"`
+	Uri            string `json:"uri" bson:"uri"`
+	Key            string `json:"key" bson:"key"`
+	Secret         string `json:"secret" bson:"secret"`
+	Token          string `json:"token" bson:"token"`
+	ForcePathStyle bool   `json:"force_path_style" bson:"force_path_style"`
+	UseAccelerate  bool   `json:"use_accelerate" bson:"use_accelerate"`
 }
 
 func ParseStorageSettingsRequest(source io.Reader) (*StorageSettings, error) {

--- a/s3/filestorage.go
+++ b/s3/filestorage.go
@@ -77,7 +77,7 @@ type SimpleStorageService struct {
 
 // NewSimpleStorageServiceStatic create new S3 client model.
 // AWS authentication keys are automatically reloaded from env variables.
-func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri string, tag_artifact, forcePathStyle bool) (*SimpleStorageService, error) {
+func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri string, tag_artifact, forcePathStyle bool, useAccelerate bool) (*SimpleStorageService, error) {
 	credentials := credentials.NewStaticCredentials(key, secret, token)
 	config := aws.NewConfig().WithCredentials(credentials).WithRegion(region)
 
@@ -91,8 +91,12 @@ func NewSimpleStorageServiceStatic(bucket, key, secret, region, token, uri strin
 	// Setting S3ForcePathStyle to false forces virtual-hosted style.
 	config.S3ForcePathStyle = aws.Bool(forcePathStyle)
 
-	sess := session.New(config)
+	// If `true`, enables the S3 Accelerate feature. For all operations
+	// compatible with S3 Accelerate will use the accelerate endpoint for
+	// requests. Requests not compatible will fall back to normal S3 requests.
+	config.S3UseAccelerate = aws.Bool(useAccelerate)
 
+	sess := session.New(config)
 	client := s3.New(sess)
 
 	return &SimpleStorageService{

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -306,13 +306,15 @@ const (
 	StorageKeyDeploymentMaxDevices   = "max_devices"
 	StorageKeyDeploymentType         = "type"
 
-	StorageKeyStorageSettingsDefaultID = "settings"
-	StorageKeyStorageSettingsBucket    = "bucket"
-	StorageKeyStorageSettingsRegion    = "region"
-	StorageKeyStorageSettingsKey       = "key"
-	StorageKeyStorageSettingsSecret    = "secret"
-	StorageKeyStorageSettingsURI       = "uri"
-	StorageKeyStorageSettingsToken     = "token"
+	StorageKeyStorageSettingsDefaultID      = "settings"
+	StorageKeyStorageSettingsBucket         = "bucket"
+	StorageKeyStorageSettingsRegion         = "region"
+	StorageKeyStorageSettingsKey            = "key"
+	StorageKeyStorageSettingsSecret         = "secret"
+	StorageKeyStorageSettingsURI            = "uri"
+	StorageKeyStorageSettingsToken          = "token"
+	StorageKeyStorageSettingsForcePathStyle = "force_path_style"
+	StorageKeyStorageSettingsUseAccelerate  = "use_accelerate"
 
 	ArtifactDependsDeviceType = "device_type"
 )
@@ -1961,12 +1963,14 @@ func (db *DataStoreMongo) SetStorageSettings(ctx context.Context, storageSetting
 	update := bson.M{
 		"$setOnInsert": bson.M{"_id": StorageKeyStorageSettingsDefaultID},
 		"$set": bson.M{
-			StorageKeyStorageSettingsBucket: storageSettings.Bucket,
-			StorageKeyStorageSettingsKey:    storageSettings.Key,
-			StorageKeyStorageSettingsSecret: storageSettings.Secret,
-			StorageKeyStorageSettingsURI:    storageSettings.Uri,
-			StorageKeyStorageSettingsRegion: storageSettings.Region,
-			StorageKeyStorageSettingsToken:  storageSettings.Token,
+			StorageKeyStorageSettingsBucket:         storageSettings.Bucket,
+			StorageKeyStorageSettingsKey:            storageSettings.Key,
+			StorageKeyStorageSettingsSecret:         storageSettings.Secret,
+			StorageKeyStorageSettingsURI:            storageSettings.Uri,
+			StorageKeyStorageSettingsRegion:         storageSettings.Region,
+			StorageKeyStorageSettingsToken:          storageSettings.Token,
+			StorageKeyStorageSettingsForcePathStyle: storageSettings.ForcePathStyle,
+			StorageKeyStorageSettingsUseAccelerate:  storageSettings.UseAccelerate,
 		},
 	}
 	updateOptions := mopts.Update()

--- a/tests/tests/test_settings_api_internal.py
+++ b/tests/tests/test_settings_api_internal.py
@@ -24,10 +24,12 @@ class TestInternalApiStorageSettings:
         data = {
             "region": "region",
             "bucket": "bucket",
-            "uri":    "https://example.com",
-            "key":    "long_key",
+            "uri": "https://example.com",
+            "key": "long_key",
             "secret": "secret",
-            "token":  "token"
+            "token": "token",
+            "force_path_style": True,
+            "use_accelerate": True,
         }
         api_client_int.set_settings(tenant_id, data)
         rx_data = api_client_int.get_settings(tenant_id)
@@ -38,18 +40,22 @@ class TestInternalApiStorageSettings:
         data1 = {
             "region": "region",
             "bucket": "bucket",
-            "uri":    "https://example.com",
-            "key":    "long_key",
+            "uri": "https://example.com",
+            "key": "long_key",
             "secret": "secret",
-            "token":  "token"
+            "token": "token",
+            "force_path_style": True,
+            "use_accelerate": True,
         }
         data2 = {
             "region": "region",
             "bucket": "new_bucket",
-            "uri":    "https://example.com",
-            "key":    "long_key",
+            "uri": "https://example.com",
+            "key": "long_key",
             "secret": "secret",
-            "token":  "token"
+            "token": "token",
+            "force_path_style": False,
+            "use_accelerate": False,
         }
         api_client_int.set_settings(tenant_id, data1)
         api_client_int.set_settings(tenant_id, data2)
@@ -59,18 +65,20 @@ class TestInternalApiStorageSettings:
         data1 = {
             "region": "region",
             "bucket": "bucket",
-            "uri":    "https://example.com",
-            "key":    "long_key",
+            "uri": "https://example.com",
+            "key": "long_key",
             "secret": "secret",
-            "token":  "token"
+            "token": "token",
+            "force_path_style": True,
+            "use_accelerate": True,
         }
         data2 = {
             "region": "",
             "bucket": "",
-            "uri":    "",
-            "key":    "",
+            "uri": "",
+            "key": "",
             "secret": "",
-            "token":  ""
+            "token": "",
         }
         api_client_int.set_settings(tenant_id, data1)
         api_client_int.set_settings(tenant_id, data2)
@@ -81,10 +89,10 @@ class TestInternalApiStorageSettings:
         data = {
             "region": "region",
             "bucket": "bucket",
-            "uri":    "https://example.com",
-            "key":    "key",
+            "uri": "https://example.com",
+            "key": "key",
             "secret": "secret",
-            "token":  "token"
+            "token": "token",
         }
         api_client_int.set_settings(tenant_id, data, 500)
 
@@ -93,9 +101,9 @@ class TestInternalApiStorageSettings:
         # 'Bucket' key is missing
         data = {
             "region": "region",
-            "uri":    "https://example.com",
-            "key":    "long_key",
+            "uri": "https://example.com",
+            "key": "long_key",
             "secret": "secret",
-            "token":  "token"
+            "token": "token",
         }
         api_client_int.set_settings(tenant_id, data, 400)


### PR DESCRIPTION
Make the AWS S3 Transfer Acceleration and the flag to force S3 Path
Style configurable on a per-tenant level.

Changelog: Title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>