### PR TITLE
Check for res before accessing its contents

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -1685,7 +1685,7 @@ func (db *DataStoreMongo) UpdateStats(ctx context.Context,
 	}
 
 	res, err := collDpl.UpdateOne(ctx, bson.M{"_id": id}, update)
-	if res.MatchedCount == 0 {
+	if res != nil && res.MatchedCount == 0 {
 		return ErrStorageInvalidID
 	}
 	return err
@@ -1919,7 +1919,7 @@ func (db *DataStoreMongo) SetDeploymentStatus(ctx context.Context, id string, st
 
 	res, err := collDpl.UpdateOne(ctx, bson.M{"_id": id}, update)
 
-	if res.MatchedCount == 0 {
+	if res != nil && res.MatchedCount == 0 {
 		return ErrStorageInvalidID
 	}
 


### PR DESCRIPTION
Changelog: Commit
Signed-off-by: Prashanth Joseph Babu <prashanthjbabu@gmail.com>

Fix for crash : 
```
runtime error: invalid memory address or nil pointer dereference
goroutine 10955815 [running]:
runtime/debug.Stack(0xc001664ba8, 0x100afa0, 0x1c4a480)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/ant0ine/go-json-rest/rest.(*RecoverMiddleware).MiddlewareFunc.func1.1(0x1cb7580, 0x150a460, 0xc044c2a3c0)
        /go/src/github.com/mendersoftware/deployments/vendor/github.com/ant0ine/go-json-rest/rest/recover.go:41 +0x5a
panic(0x100afa0, 0x1c4a480)
        /usr/local/go/src/runtime/panic.go:969 +0x166
github.com/mendersoftware/deployments/store/mongo.(*DataStoreMongo).SetDeploymentStatus(0xc0003a2020, 0x150a2e0, 0xc044c2a750, 0xc03a2340c0, 0x24, 0x1147efe, 0xa, 0xc02897bdf0657a47, 0x4b82f713ccde, 0x1cb9be0, ...)
        /go/src/github.com/mendersoftware/deployments/store/mongo/datastore_mongo.go:1903 +0x376
github.com/mendersoftware/deployments/app.(*Deployments).recalcDeploymentStatus(0xc0002d6050, 0x150a2e0, 0xc044c2a750, 0xc066cbe840, 0x24, 0xc066cbe840)
        /go/src/github.com/mendersoftware/deployments/app/app.go:1291 +0xcc
github.com/mendersoftware/deployments/app.(*Deployments).UpdateDeviceDeploymentStatus(0xc0002d6050, 0x150a2e0, 0xc044c2a750, 0xc03ea5b07f, 0x24, 0xc04120c480, 0x24, 0xc04b13a668, 0x7, 0x0, ...)
        /go/src/github.com/mendersoftware/deployments/app/app.go:1277 +0x4f7
github.com/mendersoftware/deployments/api/http.(*DeploymentsApiHandlers).PutDeploymentStatusForDevice(0xc0002e0000, 0x150a460, 0xc044c2a3c0, 0xc0118acf80)
        /go/src/github.com/mendersoftware/deployments/api/http/api_deployments.go:1123 +0x31f
github.com/ant0ine/go-json-rest/rest.(*router).AppFunc.func1(0x150a460, 0xc044c2a3c0, 0xc0118acf80)

```

RCA: `res.MatchedCount` was accessed even when `res` was `nil` when mongodb faced an error during updation of document

Fix : Only access `res.MatchedCount` if `res` is not `nil`