### PR TITLE
MEN-4813: avoid race condition when aborting deployments

### DIFF
--- a/model/deployment.go
+++ b/model/deployment.go
@@ -16,12 +16,13 @@ package model
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"time"
 
-	"github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/pkg/errors"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // Errors
@@ -234,12 +235,13 @@ func (d *Deployment) IsNotPending() bool {
 }
 
 func (d *Deployment) IsFinished() bool {
-	if d.MaxDevices <= 0 || ((d.Stats[DeviceDeploymentStatusAlreadyInst] +
-		d.Stats[DeviceDeploymentStatusSuccess] +
-		d.Stats[DeviceDeploymentStatusFailure] +
-		d.Stats[DeviceDeploymentStatusNoArtifact] +
-		d.Stats[DeviceDeploymentStatusDecommissioned] +
-		d.Stats[DeviceDeploymentStatusAborted]) >= d.MaxDevices) {
+	if d.Finished != nil ||
+		d.MaxDevices > 0 && ((d.Stats[DeviceDeploymentStatusAlreadyInst]+
+			d.Stats[DeviceDeploymentStatusSuccess]+
+			d.Stats[DeviceDeploymentStatusFailure]+
+			d.Stats[DeviceDeploymentStatusNoArtifact]+
+			d.Stats[DeviceDeploymentStatusDecommissioned]+
+			d.Stats[DeviceDeploymentStatusAborted]) >= d.MaxDevices) {
 		return true
 	}
 

--- a/model/deployment_external_test.go
+++ b/model/deployment_external_test.go
@@ -358,7 +358,7 @@ func TestDeploymentGetStatus(t *testing.T) {
 			OutputStatus: "pending",
 		},
 		"Empty": {
-			OutputStatus: "finished",
+			OutputStatus: "pending",
 		},
 		//verify we count 'already-installed' towards 'inprogress'
 		"pending + already-installed": {

--- a/model/device_deployment_external_test.go
+++ b/model/device_deployment_external_test.go
@@ -167,3 +167,12 @@ func TestDeviceDeploymentIsFinished(t *testing.T) {
 		}
 	}
 }
+
+func TestDeviceDeploymentIsFinishedWithFinishedTimestamp(t *testing.T) {
+	now := time.Now()
+	deployment := Deployment{}
+	assert.False(t, deployment.IsFinished())
+
+	deployment = Deployment{Finished: &now}
+	assert.True(t, deployment.IsFinished())
+}

--- a/tests/tests/test_deployment.py
+++ b/tests/tests/test_deployment.py
@@ -461,11 +461,11 @@ class TestDeployment:
                         token=dev.fake_token, devdepid=nextdep.id, status="rebooting"
                     )
                     self.d.verify_deployment_stats(depid, expected={"rebooting": 1})
-                    # deployment is in progress again
+                    # deployment is still finished
                     dep = self.d.client.Management_API.Show_Deployment(
                         Authorization="foo", id=depid
                     ).result()[0]
-                    assert dep.status == "inprogress"
+                    assert dep.status == "finished"
 
                     # go on, let's pretend that the artifact is already installed
                     nodep = dc.get_next_deployment(


### PR DESCRIPTION
If the user aborts a deployment while devices are updating their status,
it can happen a stats recalculation is performed in parallel with the
abort operation. In this case, deployment's end time is set but the
status is not "finished", making it impossible to abort the deployment.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>