### PR TITLE
removed deprecated ci job image override to align with ci templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,8 +30,5 @@ test:acceptance_tests:
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_DRIVER: overlay2
 
-test:static:
-  image: golang:1.14
-
 test:unit:
   image: golang:1.14


### PR DESCRIPTION
- only for static tests though as unit tests still need to be aligned with go:1.14

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>