### PR TITLE
MEN-4525: use internal end-point to decommission devices

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -1397,6 +1397,14 @@ func (d *DeploymentsApiHandlers) GetDeploymentLogForDevice(w rest.ResponseWriter
 
 func (d *DeploymentsApiHandlers) DecommissionDevice(w rest.ResponseWriter, r *rest.Request) {
 	ctx := r.Context()
+	tenantID := r.PathParam("tenantID")
+	if tenantID != "" {
+		ctx = identity.WithContext(r.Context(), &identity.Identity{
+			Tenant:   tenantID,
+			IsDevice: true,
+		})
+	}
+
 	l := requestlog.GetRequestLogger(r)
 
 	id := r.PathParam("id")

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -51,7 +51,6 @@ const (
 	ApiUrlManagementDeploymentsDevices     = ApiUrlManagement + "/deployments/:id/devices"
 	ApiUrlManagementDeploymentsDevicesList = ApiUrlManagement + "/deployments/:id/devices/list"
 	ApiUrlManagementDeploymentsLog         = ApiUrlManagement + "/deployments/:id/devices/:devid/log"
-	ApiUrlManagementDeploymentsDeviceId    = ApiUrlManagement + "/deployments/devices/:id"
 	ApiUrlManagementDeploymentsDeviceList  = ApiUrlManagement + "/deployments/:id/device_list"
 
 	ApiUrlManagementReleases = ApiUrlManagement + "/deployments/releases"
@@ -67,6 +66,7 @@ const (
 	ApiUrlInternalHealth                         = ApiUrlInternal + "/health"
 	ApiUrlInternalTenants                        = ApiUrlInternal + "/tenants"
 	ApiUrlInternalTenantDeployments              = ApiUrlInternal + "/tenants/:tenant/deployments"
+	ApiUrlInternalTenantDeploymentsDevice        = ApiUrlInternal + "/tenants/:tenant/deployments/devices/:id"
 	ApiUrlInternalTenantArtifacts                = ApiUrlInternal + "/tenants/:tenant/artifacts"
 	ApiUrlInternalTenantStorageSettings          = ApiUrlInternal + "/tenants/:tenant/storage/settings"
 	ApiUrlInternalDeviceConfigurationDeployments = ApiUrlInternal + "/tenants/:tenant/configuration/deployments/:deployment_id/devices/:device_id"
@@ -192,8 +192,6 @@ func NewDeploymentsResourceRoutes(controller *DeploymentsApiHandlers) []*rest.Ro
 			controller.GetDevicesListForDeployment),
 		rest.Get(ApiUrlManagementDeploymentsLog,
 			controller.GetDeploymentLogForDevice),
-		rest.Delete(ApiUrlManagementDeploymentsDeviceId,
-			controller.DecommissionDevice),
 		rest.Get(ApiUrlManagementDeploymentsDeviceList,
 			controller.GetDeploymentDeviceList),
 
@@ -237,6 +235,7 @@ func TenantRoutes(controller *DeploymentsApiHandlers) []*rest.Route {
 	return []*rest.Route{
 		rest.Post(ApiUrlInternalTenants, controller.ProvisionTenantsHandler),
 		rest.Get(ApiUrlInternalTenantDeployments, controller.DeploymentsPerTenantHandler),
+		rest.Delete(ApiUrlInternalTenantDeploymentsDevice, controller.DecommissionDevice),
 		rest.Post(ApiUrlInternalTenantArtifacts, controller.NewImageForTenantHandler),
 
 		// per-tenant storage settings

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -207,6 +207,7 @@ paths:
           description: Internal server error.
           schema:
            $ref: "#/definitions/Error"
+
   /tenants/{id}/deployments:
     get:
       operationId: Get Deployments
@@ -278,6 +279,32 @@ paths:
               description: Total number of deployments matching query.
         400:
           $ref: "#/responses/InvalidRequestError"
+
+  /tenants/{tenant_id}/deployments/devices/{id}:
+    delete:
+      operationId: Remove Device from Deployments
+      tags:
+        - Internal API
+      summary: Remove device from all deployments
+      description: Set 'decommissioned' status to all pending device deployments for a given device
+      parameters:
+        - name: tenant_id
+          in: path
+          type: string
+          description: Tenant ID
+          required: true
+        - name: id
+          in: path
+          description: System wide device identifier
+          required: true
+          type: string
+      responses:
+        204:
+          description: Device was removed
+        500:
+          description: Internal server error.
+          schema:
+              $ref: "#/definitions/Error"
 
   /tenants/{id}/artifacts:
     post:

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -503,31 +503,6 @@ paths:
         500:
           $ref: "#/responses/InternalServerError"
 
-  /deployments/devices/{id}:
-    delete:
-      operationId: Remove Device from Deployments
-      tags:
-        - Management API
-      security:
-        - ManagementJWT: []
-      summary: Remove device from all deployments
-      description: Set 'decommissioned' status to all pending device deployments for a given device
-      parameters:
-        - name: id
-          in: path
-          description: System wide device identifier
-          required: true
-          type: string
-      responses:
-        204:
-          description: Device was removed
-        401:
-          $ref: '#/responses/UnauthorizedError'
-        500:
-          description: Internal server error.
-          schema:
-              $ref: "#/definitions/Error"
-
   /deployments/releases:
     get:
       operationId: List Releases


### PR DESCRIPTION
We move the decommissioning end-point from management to internal, where
it really belongs to. This commit breaks back-compatibility, but the
endpoint wasn't meant to be used by users and it is safer to remove it
straight away.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>