### PR TITLE
MEN-5259: add back /deployments/devices/{id} end-point to management

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -1538,6 +1538,21 @@ func (d *DeploymentsApiHandlers) GetDeploymentLogForDevice(w rest.ResponseWriter
 	d.view.RenderDeploymentLog(w, *depl)
 }
 
+func (d *DeploymentsApiHandlers) AbortDeviceDeployments(w rest.ResponseWriter, r *rest.Request) {
+	ctx := r.Context()
+	l := requestlog.GetRequestLogger(r)
+
+	id := r.PathParam("id")
+	err := d.app.AbortDeviceDeployments(ctx, id)
+
+	switch err {
+	case nil, app.ErrStorageNotFound:
+		d.view.RenderEmptySuccessResponse(w)
+	default:
+		d.view.RenderInternalError(w, r, err, l)
+	}
+}
+
 func (d *DeploymentsApiHandlers) DecommissionDevice(w rest.ResponseWriter, r *rest.Request) {
 	ctx := r.Context()
 	tenantID := r.PathParam("tenantID")

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -54,6 +54,7 @@ const (
 	ApiUrlManagementDeploymentsDevicesList = ApiUrlManagement + "/deployments/:id/devices/list"
 	ApiUrlManagementDeploymentsLog         = ApiUrlManagement +
 		"/deployments/:id/devices/:devid/log"
+	ApiUrlManagementDeploymentsDeviceId   = ApiUrlManagement + "/deployments/devices/:id"
 	ApiUrlManagementDeploymentsDeviceList = ApiUrlManagement + "/deployments/:id/device_list"
 
 	ApiUrlManagementReleases     = ApiUrlManagement + "/deployments/releases"
@@ -209,6 +210,8 @@ func NewDeploymentsResourceRoutes(controller *DeploymentsApiHandlers) []*rest.Ro
 			controller.GetDevicesListForDeployment),
 		rest.Get(ApiUrlManagementDeploymentsLog,
 			controller.GetDeploymentLogForDevice),
+		rest.Delete(ApiUrlManagementDeploymentsDeviceId,
+			controller.AbortDeviceDeployments),
 		rest.Get(ApiUrlManagementDeploymentsDeviceList,
 			controller.GetDeploymentDeviceList),
 

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -48,6 +48,20 @@ func (_m *App) AbortDeployment(ctx context.Context, deploymentID string) error {
 	return r0
 }
 
+// AbortDeviceDeployments provides a mock function with given fields: ctx, deviceID
+func (_m *App) AbortDeviceDeployments(ctx context.Context, deviceID string) error {
+	ret := _m.Called(ctx, deviceID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, deviceID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CreateDeployment provides a mock function with given fields: ctx, constructor
 func (_m *App) CreateDeployment(ctx context.Context, constructor *model.DeploymentConstructor) (string, error) {
 	ret := _m.Called(ctx, constructor)

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -525,6 +525,32 @@ paths:
         500:
           $ref: "#/responses/InternalServerError"
 
+  /deployments/devices/{id}:
+    delete:
+      operationId: Abort Deployments for a Device
+      tags:
+        - Management API
+      security:
+        - ManagementJWT: []
+      summary: Abort all the active and pending Deployments for a Device
+      description: |
+        Abort all the active and pending Deployments for the specified Device.
+      parameters:
+        - name: id
+          in: path
+          description: System wide device identifier
+          required: true
+          type: string
+      responses:
+        204:
+          description: Operation completed successfully.
+        401:
+          $ref: '#/responses/UnauthorizedError'
+        500:
+          description: Internal server error.
+          schema:
+              $ref: "#/definitions/Error"
+
   /deployments/releases:
     get:
       deprecated: true


### PR DESCRIPTION
Commit `7384a418c5a5fae3d7a71b13fb6beacef289a4e8` moved the end-point
mentioned above to internal, where it really belongs to because the
decommissioning workflow uses it. Still, the end-point makes sense. It
now aborts all the active and pending deployments for a device.

This commit brings back the old end-point, changing its behavior to mark
active and pending device deployments as aborted.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>