### PR TITLE
model: Configurations are decoded "raw" if not a string

### DIFF
--- a/api/http/api_deployments_test.go
+++ b/api/http/api_deployments_test.go
@@ -501,8 +501,22 @@ func TestControllerPostConfigurationDeployment(t *testing.T) {
 	}{
 		"ok": {
 			InputBodyObject: &model.ConfigurationDeploymentConstructor{
-				Name:          "name",
-				Configuration: "configuration",
+				Name:          "NYC Production",
+				Configuration: []byte("App 123"),
+			},
+			InputTenantID:     "foo",
+			InputDeviceID:     "bar",
+			InputDeploymentID: "baz",
+			JSONResponseParams: h.JSONResponseParams{
+				OutputStatus:     http.StatusCreated,
+				OutputBodyObject: nil,
+				OutputHeaders:    map[string]string{"Location": "./deployments/baz"},
+			},
+		},
+		"ok, object configuration encoding": {
+			InputBodyObject: map[string]interface{}{
+				"name":          "NYC Production",
+				"configuration": map[string]interface{}{"App": "123"},
 			},
 			InputTenantID:     "foo",
 			InputDeviceID:     "bar",
@@ -536,7 +550,7 @@ func TestControllerPostConfigurationDeployment(t *testing.T) {
 		"ko, internal error": {
 			InputBodyObject: &model.ConfigurationDeploymentConstructor{
 				Name:          "foo",
-				Configuration: "bar",
+				Configuration: []byte("bar"),
 			},
 			InputTenantID:                           "foo",
 			InputDeviceID:                           "bar",
@@ -550,7 +564,7 @@ func TestControllerPostConfigurationDeployment(t *testing.T) {
 		"ko, conflict": {
 			InputBodyObject: &model.ConfigurationDeploymentConstructor{
 				Name:          "foo",
-				Configuration: "bar",
+				Configuration: []byte("bar"),
 			},
 			InputTenantID:                           "foo",
 			InputDeviceID:                           "bar",

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -434,7 +434,7 @@ func TestCreateDeviceConfigurationDeployment(t *testing.T) {
 		"ok": {
 			inputConstructor: &model.ConfigurationDeploymentConstructor{
 				Name:          "foo",
-				Configuration: "bar",
+				Configuration: []byte("bar"),
 			},
 			inputDeviceID:     "foo-device",
 			inputDeploymentID: "foo-deployment",
@@ -449,7 +449,7 @@ func TestCreateDeviceConfigurationDeployment(t *testing.T) {
 		"insert error": {
 			inputConstructor: &model.ConfigurationDeploymentConstructor{
 				Name:          "foo",
-				Configuration: "bar",
+				Configuration: []byte("bar"),
 			},
 			inputDeploymentStorageInsertError: errors.New("insert error"),
 			callInventory:                     true,
@@ -460,7 +460,7 @@ func TestCreateDeviceConfigurationDeployment(t *testing.T) {
 		"inventory error": {
 			inputConstructor: &model.ConfigurationDeploymentConstructor{
 				Name:          "foo",
-				Configuration: "bar",
+				Configuration: []byte("bar"),
 			},
 			inventoryError: errors.New("inventory error"),
 			callInventory:  true,

--- a/model/configuration_deployment_test.go
+++ b/model/configuration_deployment_test.go
@@ -32,12 +32,13 @@ func TestConfigurationDeploymentValidate(t *testing.T) {
 		"ok": {
 			inputConstructor: ConfigurationDeploymentConstructor{
 				Name:          "foo",
-				Configuration: "foo",
+				Configuration: []byte("foo"),
 			},
 		},
 		"ko, missing name": {
 			inputConstructor: ConfigurationDeploymentConstructor{
-				Configuration: "foo"},
+				Configuration: []byte("foo"),
+			},
 			outputError: errors.New("name: cannot be blank."),
 		},
 		"ko, missing configuration": {
@@ -77,7 +78,7 @@ func TestNewDeploymentFromConfigurationDeploymentConstructor(t *testing.T) {
 		"ok": {
 			inputConstructor: &ConfigurationDeploymentConstructor{
 				Name:          "foo",
-				Configuration: "bar",
+				Configuration: []byte("bar"),
 			},
 			inputDeploymentID: "baz",
 		},


### PR DESCRIPTION
TL;DR: The new workflow uses a JSON object for the configuration parameter which broke with the old behavior which expects an escaped string with the configuration object.

The new behavior is backward compatible in that configuration still
escapes JSON strings.

mendersoftware/azure-iot-manager#16