### PR TITLE
client/inventory: ignore 404 Not Found error when asking for device groups

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -992,7 +992,7 @@ func (d *Deployments) getDeploymentGroups(
 	}
 
 	groups, err := d.inventoryClient.GetDeviceGroups(ctx, id.Tenant, devices[0])
-	if err != nil {
+	if err != nil && err != inventory.ErrDevNotFound {
 		return nil, err
 	}
 	return groups, nil

--- a/client/inventory/client.go
+++ b/client/inventory/client.go
@@ -44,6 +44,7 @@ const (
 // Errors
 var (
 	ErrFilterNotFound = errors.New("Filter with given ID not found in the inventory.")
+	ErrDevNotFound    = errors.New("Device with given ID not found in the inventory.")
 )
 
 // Client is the inventory client
@@ -188,6 +189,9 @@ func (c *client) GetDeviceGroups(ctx context.Context, tenantId, deviceId string)
 	defer rsp.Body.Close()
 
 	if rsp.StatusCode != http.StatusOK {
+		if rsp.StatusCode == http.StatusNotFound {
+			return []string{}, nil
+		}
 		return nil, errors.Errorf(
 			"get device groups request failed with unexpected status: %v",
 			rsp.StatusCode,

--- a/client/inventory/client_test.go
+++ b/client/inventory/client_test.go
@@ -145,12 +145,18 @@ func TestGetDeviceGroups(t *testing.T) {
 			responseBody:   model.DeviceGroups{Groups: []string{"foo"}},
 			expectedGroups: []string{"foo"},
 		},
-		"not found": {
+		"ok, not found": {
+
+			ctx:            context.TODO(),
+			responseCode:   http.StatusNotFound,
+			expectedGroups: []string{},
+		},
+		"some error": {
 
 			ctx:          context.TODO(),
-			responseCode: http.StatusNotFound,
+			responseCode: http.StatusInternalServerError,
 
-			outError: errors.New("get device groups request failed with unexpected status: 404"),
+			outError: errors.New("get device groups request failed with unexpected status: 500"),
 		},
 	}
 

--- a/tests/tests/test_deployment.py
+++ b/tests/tests/test_deployment.py
@@ -176,6 +176,29 @@ class TestDeployment:
             # deleting artifact should succeed
             ac.delete_artifact(artid)
 
+    def test_single_device_deployment_device_not_in_inventory(self):
+        """Try to create single device deployment for a device wich is not
+        in the inventory"""
+        dev = Device()
+
+        self.d.log.info("fake device with ID: %s", dev.devid)
+
+        data = b"foo_bar"
+        artifact_name = "hammer-update-" + str(uuid4())
+        # come up with an artifact
+        with artifact_from_data(
+            name=artifact_name, data=data, devicetype=dev.device_type
+        ) as art:
+            ac = SimpleArtifactsClient()
+            artid = ac.add_artifact(
+                description="some description", size=art.size, data=art
+            )
+
+            newdep = self.d.make_new_deployment(
+                name="fake deployment", artifact_name=artifact_name, devices=[dev.devid]
+            )
+            depid = self.d.add_deployment(newdep)
+
     def test_deployments_new_no_artifact(self):
         """Try to add deployment without an artifact, verify that it failed with 422"""
         dev = Device()
@@ -215,15 +238,15 @@ class TestDeployment:
         artifact_name = "pagination-test-" + str(uuid4())
         # come up with an artifact
         with artifact_from_data(
-                name=artifact_name, data=data, devicetype=device_type
+            name=artifact_name, data=data, devicetype=device_type
         ) as art:
             ac = SimpleArtifactsClient()
-            ac.add_artifact(
-                description="some description", size=art.size, data=art
-            )
+            ac.add_artifact(description="some description", size=art.size, data=art)
 
             new_dep = self.d.make_new_deployment(
-                name="pagination deployment", artifact_name=artifact_name, devices=device_ids
+                name="pagination deployment",
+                artifact_name=artifact_name,
+                devices=device_ids,
             )
             dep_id = self.d.add_deployment(new_dep)
 
@@ -253,7 +276,7 @@ class TestDeployment:
                 Authorization="foo",
                 deployment_id=dep_id,
                 page=2,
-                per_page=default_per_page
+                per_page=default_per_page,
             ).result()[0]
             assert len(res) == devices_qty_on_second_page
 


### PR DESCRIPTION
If the device is not present in the inventory, the deployment will not have an information about the device groups.
As a result, only users with access to all device will see the deployment.
One important note about this change - in theory we could return 400 Bad Request, when user will try to create single device deployment for the device which doesn't exist, but originally, we we were not checking if the device exists (and we still don't check that when there is more than one device in the deployment constructor).
I want to be consistent and I don't want to introduce potential backward compatibility, because of implicit check needed by RBAC.
If we want to check if the devices from the list provided when creating deployment exist, this should be an explicit check, and the behavior should be documented.