### PR TITLE
Change alive and healthcheck status code to 200

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -192,7 +192,7 @@ func NewDeploymentsApiHandlers(
 }
 
 func (u *DeploymentsApiHandlers) AliveHandler(w rest.ResponseWriter, r *rest.Request) {
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 }
 
 func (u *DeploymentsApiHandlers) HealthHandler(w rest.ResponseWriter, r *rest.Request) {
@@ -206,7 +206,7 @@ func (u *DeploymentsApiHandlers) HealthHandler(w rest.ResponseWriter, r *rest.Re
 		rest_utils.RestErrWithLog(w, r, l, err, http.StatusServiceUnavailable)
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 }
 
 func getReleaseOrImageFilter(r *rest.Request, paginated bool) *model.ReleaseOrImageFilter {

--- a/api/http/api_deployments_test.go
+++ b/api/http/api_deployments_test.go
@@ -51,7 +51,7 @@ func TestAlive(t *testing.T) {
 	d := NewDeploymentsApiHandlers(nil, nil, nil)
 	api := setUpRestTest(ApiUrlInternalAlive, rest.Get, d.AliveHandler)
 	recorded := test.RunRequest(t, api.MakeHandler(), req)
-	recorded.CodeIs(http.StatusNoContent)
+	recorded.CodeIs(http.StatusOk)
 }
 
 func TestHealthCheck(t *testing.T) {
@@ -65,7 +65,7 @@ func TestHealthCheck(t *testing.T) {
 		ResponseBody interface{}
 	}{{
 		Name:         "ok",
-		ResponseCode: http.StatusNoContent,
+		ResponseCode: http.StatusOk,
 	}, {
 		Name:         "error: app unhealthy",
 		AppError:     errors.New("*COUGH! COUGH!*"),
@@ -1347,7 +1347,7 @@ func TestGetDeploymentForDevice(t *testing.T) {
 			return app
 		}(),
 
-		StatusCode: http.StatusNoContent,
+		StatusCode: http.StatusOK,
 	}}
 	for i := range testCases {
 		tc := testCases[i]


### PR DESCRIPTION
Currently these two APIs return status code 204 (no content), which is
fine but it doesn't play well with systems that require status code 200
for healthcheck and alive APIs. One of these is Kubernetes Ingress. The
Ingress by default (and cannot be changed) expects the status for
HTTP(s) healthcheck API be 200. This commit allows the deployment
service be configured behind an Ingress.

Changelog: Commit

Signed-off-by: Amin Hassani <ahassani@nuro.ai>