### PR TITLE
fix the device_type handling in the deployments/next handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1136,12 +1136,16 @@ func (d *Deployments) assignArtifact(
 	}
 
 	if err := d.db.AssignArtifact(
-		ctx, deviceDeployment.DeviceId, deviceDeployment.DeploymentId, artifact); err != nil {
+		ctx,
+		deviceDeployment.DeviceId,
+		deviceDeployment.DeploymentId,
+		artifact,
+		installed.DeviceType,
+	); err != nil {
 		return errors.Wrap(err, "Assigning artifact to the device deployment")
 	}
 
 	deviceDeployment.Image = artifact
-	deviceDeployment.DeviceType = installed.DeviceType
 
 	return nil
 }
@@ -1334,12 +1338,11 @@ func (d *Deployments) GetDeploymentForDeviceWithCurrent(ctx context.Context, dev
 		}, nil
 	}
 
-	// assign artifact only if the artifact was not assigned previously or the device type has
-	// changed
+	// assign artifact only if the artifact was not assigned previously
+	// or the deployment is not in progress yet and device type has changed
 	if deviceDeployment.Image == nil ||
-		len(deviceDeployment.DeviceType) == 0 ||
-		deviceDeployment.DeviceType != installed.DeviceType {
-
+		(deviceDeployment.Status == model.DeviceDeploymentStatusPending &&
+			deviceDeployment.DeviceType != installed.DeviceType) {
 		if err := d.assignArtifact(ctx, deployment, deviceDeployment, installed); err != nil {
 			return nil, err
 		}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ type DataStore interface {
 	UpdateDeviceDeploymentLogAvailability(ctx context.Context,
 		deviceID string, deploymentID string, log bool) error
 	AssignArtifact(ctx context.Context, deviceID string,
-		deploymentID string, artifact *model.Image) error
+		deploymentID string, artifact *model.Image, deviceType string) error
 	AggregateDeviceDeploymentByStatus(ctx context.Context,
 		id string) (model.Stats, error)
 	GetDeviceStatusesForDeployment(ctx context.Context,

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -69,13 +69,13 @@ func (_m *DataStore) AggregateDeviceDeploymentByStatus(ctx context.Context, id s
 	return r0, r1
 }
 
-// AssignArtifact provides a mock function with given fields: ctx, deviceID, deploymentID, artifact
-func (_m *DataStore) AssignArtifact(ctx context.Context, deviceID string, deploymentID string, artifact *model.Image) error {
-	ret := _m.Called(ctx, deviceID, deploymentID, artifact)
+// AssignArtifact provides a mock function with given fields: ctx, deviceID, deploymentID, artifact, deviceType
+func (_m *DataStore) AssignArtifact(ctx context.Context, deviceID string, deploymentID string, artifact *model.Image, deviceType string) error {
+	ret := _m.Called(ctx, deviceID, deploymentID, artifact, deviceType)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, *model.Image) error); ok {
-		r0 = rf(ctx, deviceID, deploymentID, artifact)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, *model.Image, string) error); ok {
+		r0 = rf(ctx, deviceID, deploymentID, artifact, deviceType)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -353,6 +353,7 @@ const (
 	StorageKeyDeviceDeploymentFinished       = "finished"
 	StorageKeyDeviceDeploymentIsLogAvailable = "log"
 	StorageKeyDeviceDeploymentArtifact       = "image"
+	StorageKeyDeviceDeploymentDeviceType     = "devicetype"
 
 	StorageKeyDeploymentName         = "deploymentconstructor.name"
 	StorageKeyDeploymentArtifactName = "deploymentconstructor.artifactname"
@@ -1328,7 +1329,7 @@ func (db *DataStoreMongo) UpdateDeviceDeploymentLogAvailability(ctx context.Cont
 
 // AssignArtifact assigns artifact to the device deployment
 func (db *DataStoreMongo) AssignArtifact(ctx context.Context,
-	deviceID string, deploymentID string, artifact *model.Image) error {
+	deviceID string, deploymentID string, artifact *model.Image, deviceType string) error {
 
 	// Verify ID formatting
 	if len(deviceID) == 0 ||
@@ -1348,11 +1349,11 @@ func (db *DataStoreMongo) AssignArtifact(ctx context.Context,
 
 	update := bson.D{
 		{Key: "$set", Value: bson.M{
-			StorageKeyDeviceDeploymentArtifact: artifact}},
+			StorageKeyDeviceDeploymentArtifact:   artifact,
+			StorageKeyDeviceDeploymentDeviceType: deviceType}},
 	}
 
-	// NOTE <Review> Perhaps this should be UpdateOne ?
-	if res, err := collDevs.UpdateMany(ctx, selector, update); err != nil {
+	if res, err := collDevs.UpdateOne(ctx, selector, update); err != nil {
 		return err
 	} else if res.MatchedCount == 0 {
 		return ErrStorageNotFound


### PR DESCRIPTION
On the device_type change, deployments service is trying to select new
artfiact for the device deployment.
With this change, deployments service will:
- save the device_type with the device deployment object;
- try to update the artifact assigned to the device deployment
  only if the device_type has changed and the device deployment
  is not in progress