### PR TITLE
perf: Use indexes to sort queries for next and last deployment for device

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1156,10 +1156,7 @@ func (d *Deployments) getDeploymentForDevice(ctx context.Context,
 	deviceID string) (*model.Deployment, *model.DeviceDeployment, error) {
 
 	// Retrieve device deployment
-	deviceDeployment, err := d.db.FindOldestDeploymentForDeviceIDWithStatuses(
-		ctx,
-		deviceID,
-		model.ActiveDeploymentStatuses()...)
+	deviceDeployment, err := d.db.FindOldestActiveDeviceDeployment(ctx, deviceID)
 
 	if err != nil {
 		return nil, nil, errors.Wrap(err,
@@ -1191,10 +1188,7 @@ func (d *Deployments) getNewDeploymentForDevice(ctx context.Context,
 
 	var lastDeployment *time.Time
 	//get latest device deployment for the device;
-	deviceDeployment, err := d.db.FindLatestDeploymentForDeviceIDWithStatuses(
-		ctx,
-		deviceID,
-		model.InactiveDeploymentStatuses()...)
+	deviceDeployment, err := d.db.FindLatestInactiveDeviceDeployment(ctx, deviceID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err,
 			"Searching for latest active deployment for the device")
@@ -1637,10 +1631,7 @@ func (d *Deployments) updateDeviceDeploymentsStatus(
 ) error {
 	var latestDeployment *time.Time
 	// Retrieve active device deployment for the device
-	deviceDeployment, err := d.db.FindOldestDeploymentForDeviceIDWithStatuses(
-		ctx,
-		deviceId,
-		model.ActiveDeploymentStatuses()...)
+	deviceDeployment, err := d.db.FindOldestActiveDeviceDeployment(ctx, deviceId)
 	if err != nil {
 		return errors.Wrap(err, "Searching for active deployment for the device")
 	} else if deviceDeployment != nil {
@@ -1656,10 +1647,7 @@ func (d *Deployments) updateDeviceDeploymentsStatus(
 		latestDeployment = deviceDeployment.Created
 	} else {
 		// get latest device deployment for the device
-		deviceDeployment, err := d.db.FindLatestDeploymentForDeviceIDWithStatuses(
-			ctx,
-			deviceId,
-			model.InactiveDeploymentStatuses()...)
+		deviceDeployment, err := d.db.FindLatestInactiveDeviceDeployment(ctx, deviceId)
 		if err != nil {
 			return errors.Wrap(err, "Searching for latest active deployment for the device")
 		} else if deviceDeployment == nil {

--- a/app/status_test.go
+++ b/app/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -127,12 +127,8 @@ func TestGetDeploymentForDeviceWithCurrent(t *testing.T) {
 	fs := &fs_mocks.FileStorage{}
 	db := mocks.DataStore{}
 
-	call := db.On("FindOldestDeploymentForDeviceIDWithStatuses", ctx, devId).Return(
+	db.On("FindOldestActiveDeviceDeployment", ctx, devId).Return(
 		fakeDeviceDeployment, nil)
-	// Add variadic arguments
-	for _, status := range model.ActiveDeploymentStatuses() {
-		call.Arguments = append(call.Arguments, interface{}(status))
-	}
 
 	db.On("FindDeploymentByID", ctx, fakeDeployment.Id).Return(
 		fakeDeployment, nil).Once()
@@ -278,7 +274,7 @@ func TestDecommissionDevice(t *testing.T) {
 				},
 			},
 		},
-		"FindOldestDeploymentForDeviceIDWithStatuses error": {
+		"FindOldestActiveDeviceDeployment error": {
 			inputDeviceId:       "foo",
 			inputDeploymentId:   "bar",
 			inputDeploymentName: "foo",
@@ -294,16 +290,12 @@ func TestDecommissionDevice(t *testing.T) {
 			ctx := context.TODO()
 			db := mocks.DataStore{}
 
-			call := db.On("FindOldestDeploymentForDeviceIDWithStatuses",
+			db.On("FindOldestActiveDeviceDeployment",
 				ctx, tc.inputDeviceId).
 				Return(
 					tc.findOldestDeploymentForDeviceIDWithStatusesDeployment,
 					tc.findOldestDeploymentForDeviceIDWithStatusesError,
 				)
-			// Add variadic arguments
-			for _, status := range model.ActiveDeploymentStatuses() {
-				call.Arguments = append(call.Arguments, status)
-			}
 
 			db.On("GetDeviceDeployment", ctx, tc.inputDeploymentId,
 				tc.inputDeviceId).Return(
@@ -313,16 +305,12 @@ func TestDecommissionDevice(t *testing.T) {
 				tc.inputDeploymentId, mock.AnythingOfType("model.DeviceDeploymentState")).Return(
 				tc.updateDeviceDeploymentStatusStatus, tc.updateDeviceDeploymentStatusError)
 
-			call = db.On("FindLatestDeploymentForDeviceIDWithStatuses",
+			db.On("FindLatestInactiveDeviceDeployment",
 				ctx, tc.inputDeviceId,
 			).Return(
 				tc.findLatestDeploymentForDeviceIDWithStatusesDeployment,
 				tc.findLatestDeploymentForDeviceIDWithStatusesError,
 			)
-			// Add variadic arguments
-			for _, status := range model.InactiveDeploymentStatuses() {
-				call.Arguments = append(call.Arguments, status)
-			}
 
 			db.On("FindNewerActiveDeployments", ctx, mock.AnythingOfType("*time.Time"),
 				0, 100).Return(
@@ -493,16 +481,12 @@ func TestAbortDeviceDeployments(t *testing.T) {
 			ctx := context.TODO()
 			db := mocks.DataStore{}
 
-			call := db.On("FindOldestDeploymentForDeviceIDWithStatuses",
+			db.On("FindOldestActiveDeviceDeployment",
 				ctx, tc.inputDeviceId).
 				Return(
 					tc.findOldestDeploymentForDeviceIDWithStatusesDeployment,
 					tc.findOldestDeploymentForDeviceIDWithStatusesError,
 				)
-			// Add variadic arguments
-			for _, status := range model.ActiveDeploymentStatuses() {
-				call.Arguments = append(call.Arguments, status)
-			}
 
 			db.On("GetDeviceDeployment", ctx, tc.inputDeploymentId,
 				tc.inputDeviceId).Return(
@@ -512,16 +496,12 @@ func TestAbortDeviceDeployments(t *testing.T) {
 				tc.inputDeploymentId, mock.AnythingOfType("model.DeviceDeploymentState")).Return(
 				tc.updateDeviceDeploymentStatusStatus, tc.updateDeviceDeploymentStatusError)
 
-			call = db.On("FindLatestDeploymentForDeviceIDWithStatuses",
+			db.On("FindLatestInactiveDeviceDeployment",
 				ctx, tc.inputDeviceId,
 			).Return(
 				tc.findLatestDeploymentForDeviceIDWithStatusesDeployment,
 				tc.findLatestDeploymentForDeviceIDWithStatusesError,
 			)
-			// Add variadic arguments
-			for _, status := range model.InactiveDeploymentStatuses() {
-				call.Arguments = append(call.Arguments, status)
-			}
 
 			db.On("FindNewerActiveDeployments", ctx, mock.AnythingOfType("*time.Time"),
 				0, 100).Return(

--- a/model/device_deployment.go
+++ b/model/device_deployment.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -52,6 +52,10 @@ const (
 	DeviceDeploymentStatusDecommissioned
 	// DeviceDeploymentStatusNew = (DeviceDeploymentStatusSuccess +
 	// DeviceDeploymentStatusNoArtifact) / 2
+
+	// Values within this range are active / in progress deployments
+	DeviceDeploymentStatusActiveLow  = DeviceDeploymentStatusPauseBeforeInstall
+	DeviceDeploymentStatusActiveHigh = DeviceDeploymentStatusPending
 
 	DeviceDeploymentStatusFailureStr            = "failure"
 	DeviceDeploymentStatusAbortedStr            = "aborted"

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -66,10 +66,14 @@ type DataStore interface {
 		deployment ...*model.DeviceDeployment) error
 	ExistAssignedImageWithIDAndStatuses(ctx context.Context,
 		id string, statuses ...model.DeviceDeploymentStatus) (bool, error)
-	FindOldestDeploymentForDeviceIDWithStatuses(ctx context.Context,
-		deviceID string, statuses ...model.DeviceDeploymentStatus) (*model.DeviceDeployment, error)
-	FindLatestDeploymentForDeviceIDWithStatuses(ctx context.Context,
-		deviceID string, statuses ...model.DeviceDeploymentStatus) (*model.DeviceDeployment, error)
+	FindOldestActiveDeviceDeployment(
+		ctx context.Context,
+		deviceID string,
+	) (*model.DeviceDeployment, error)
+	FindLatestInactiveDeviceDeployment(
+		ctx context.Context,
+		deviceID string,
+	) (*model.DeviceDeployment, error)
 	FindAllDeploymentsForDeviceIDWithStatuses(ctx context.Context,
 		deviceID string, statuses ...string) ([]model.DeviceDeployment, error)
 	UpdateDeviceDeploymentStatus(

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -343,20 +343,13 @@ func (_m *DataStore) FindImageByID(ctx context.Context, id string) (*model.Image
 	return r0, r1
 }
 
-// FindLatestDeploymentForDeviceIDWithStatuses provides a mock function with given fields: ctx, deviceID, statuses
-func (_m *DataStore) FindLatestDeploymentForDeviceIDWithStatuses(ctx context.Context, deviceID string, statuses ...model.DeviceDeploymentStatus) (*model.DeviceDeployment, error) {
-	_va := make([]interface{}, len(statuses))
-	for _i := range statuses {
-		_va[_i] = statuses[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx, deviceID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// FindLatestInactiveDeviceDeployment provides a mock function with given fields: ctx, deviceID
+func (_m *DataStore) FindLatestInactiveDeviceDeployment(ctx context.Context, deviceID string) (*model.DeviceDeployment, error) {
+	ret := _m.Called(ctx, deviceID)
 
 	var r0 *model.DeviceDeployment
-	if rf, ok := ret.Get(0).(func(context.Context, string, ...model.DeviceDeploymentStatus) *model.DeviceDeployment); ok {
-		r0 = rf(ctx, deviceID, statuses...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.DeviceDeployment); ok {
+		r0 = rf(ctx, deviceID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.DeviceDeployment)
@@ -364,8 +357,8 @@ func (_m *DataStore) FindLatestDeploymentForDeviceIDWithStatuses(ctx context.Con
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, ...model.DeviceDeploymentStatus) error); ok {
-		r1 = rf(ctx, deviceID, statuses...)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, deviceID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -396,20 +389,13 @@ func (_m *DataStore) FindNewerActiveDeployments(ctx context.Context, createdAfte
 	return r0, r1
 }
 
-// FindOldestDeploymentForDeviceIDWithStatuses provides a mock function with given fields: ctx, deviceID, statuses
-func (_m *DataStore) FindOldestDeploymentForDeviceIDWithStatuses(ctx context.Context, deviceID string, statuses ...model.DeviceDeploymentStatus) (*model.DeviceDeployment, error) {
-	_va := make([]interface{}, len(statuses))
-	for _i := range statuses {
-		_va[_i] = statuses[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx, deviceID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// FindOldestActiveDeviceDeployment provides a mock function with given fields: ctx, deviceID
+func (_m *DataStore) FindOldestActiveDeviceDeployment(ctx context.Context, deviceID string) (*model.DeviceDeployment, error) {
+	ret := _m.Called(ctx, deviceID)
 
 	var r0 *model.DeviceDeployment
-	if rf, ok := ret.Get(0).(func(context.Context, string, ...model.DeviceDeploymentStatus) *model.DeviceDeployment); ok {
-		r0 = rf(ctx, deviceID, statuses...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.DeviceDeployment); ok {
+		r0 = rf(ctx, deviceID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.DeviceDeployment)
@@ -417,8 +403,8 @@ func (_m *DataStore) FindOldestDeploymentForDeviceIDWithStatuses(ctx context.Con
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, ...model.DeviceDeploymentStatus) error); ok {
-		r1 = rf(ctx, deviceID, statuses...)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, deviceID)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
…vice

This commit avoids performing in memory sort, and simplifies the query
slightly utilising the enumerated deployment status ranges.
However, this still perform an index scan which is suboptimal, but it is
as good as it gets using the current data model and indexes.

Changelog: none
Ticket: MEN-5521

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>