### PR TITLE
perf: Optimize mongodb query for finding the next deployment for device

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1156,10 +1156,7 @@ func (d *Deployments) getDeploymentForDevice(ctx context.Context,
 	deviceID string) (*model.Deployment, *model.DeviceDeployment, error) {
 
 	// Retrieve device deployment
-	deviceDeployment, err := d.db.FindOldestDeploymentForDeviceIDWithStatuses(
-		ctx,
-		deviceID,
-		model.ActiveDeploymentStatuses()...)
+	deviceDeployment, err := d.db.FindOldestActiveDeviceDeployment(ctx, deviceID)
 
 	if err != nil {
 		return nil, nil, errors.Wrap(err,
@@ -1191,10 +1188,7 @@ func (d *Deployments) getNewDeploymentForDevice(ctx context.Context,
 
 	var lastDeployment *time.Time
 	//get latest device deployment for the device;
-	deviceDeployment, err := d.db.FindLatestDeploymentForDeviceIDWithStatuses(
-		ctx,
-		deviceID,
-		model.InactiveDeploymentStatuses()...)
+	deviceDeployment, err := d.db.FindLatestInactiveDeviceDeployment(ctx, deviceID)
 	if err != nil {
 		return nil, nil, errors.Wrap(err,
 			"Searching for latest active deployment for the device")
@@ -1242,6 +1236,7 @@ func (d *Deployments) createDeviceDeploymentWithStatus(
 	deviceDeployment := model.NewDeviceDeployment(deviceID, deployment.Id)
 
 	deviceDeployment.Status = status
+	deviceDeployment.Active = status.Active()
 	deviceDeployment.Created = deployment.Created
 
 	if err := d.setDeploymentDeviceCountIfUnset(ctx, deployment); err != nil {
@@ -1637,10 +1632,7 @@ func (d *Deployments) updateDeviceDeploymentsStatus(
 ) error {
 	var latestDeployment *time.Time
 	// Retrieve active device deployment for the device
-	deviceDeployment, err := d.db.FindOldestDeploymentForDeviceIDWithStatuses(
-		ctx,
-		deviceId,
-		model.ActiveDeploymentStatuses()...)
+	deviceDeployment, err := d.db.FindOldestActiveDeviceDeployment(ctx, deviceId)
 	if err != nil {
 		return errors.Wrap(err, "Searching for active deployment for the device")
 	} else if deviceDeployment != nil {
@@ -1656,10 +1648,7 @@ func (d *Deployments) updateDeviceDeploymentsStatus(
 		latestDeployment = deviceDeployment.Created
 	} else {
 		// get latest device deployment for the device
-		deviceDeployment, err := d.db.FindLatestDeploymentForDeviceIDWithStatuses(
-			ctx,
-			deviceId,
-			model.InactiveDeploymentStatuses()...)
+		deviceDeployment, err := d.db.FindLatestInactiveDeviceDeployment(ctx, deviceId)
 		if err != nil {
 			return errors.Wrap(err, "Searching for latest active deployment for the device")
 		} else if deviceDeployment == nil {

--- a/app/status_test.go
+++ b/app/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -127,12 +127,8 @@ func TestGetDeploymentForDeviceWithCurrent(t *testing.T) {
 	fs := &fs_mocks.FileStorage{}
 	db := mocks.DataStore{}
 
-	call := db.On("FindOldestDeploymentForDeviceIDWithStatuses", ctx, devId).Return(
+	db.On("FindOldestActiveDeviceDeployment", ctx, devId).Return(
 		fakeDeviceDeployment, nil)
-	// Add variadic arguments
-	for _, status := range model.ActiveDeploymentStatuses() {
-		call.Arguments = append(call.Arguments, interface{}(status))
-	}
 
 	db.On("FindDeploymentByID", ctx, fakeDeployment.Id).Return(
 		fakeDeployment, nil).Once()
@@ -278,7 +274,7 @@ func TestDecommissionDevice(t *testing.T) {
 				},
 			},
 		},
-		"FindOldestDeploymentForDeviceIDWithStatuses error": {
+		"FindOldestActiveDeviceDeployment error": {
 			inputDeviceId:       "foo",
 			inputDeploymentId:   "bar",
 			inputDeploymentName: "foo",
@@ -294,16 +290,12 @@ func TestDecommissionDevice(t *testing.T) {
 			ctx := context.TODO()
 			db := mocks.DataStore{}
 
-			call := db.On("FindOldestDeploymentForDeviceIDWithStatuses",
+			db.On("FindOldestActiveDeviceDeployment",
 				ctx, tc.inputDeviceId).
 				Return(
 					tc.findOldestDeploymentForDeviceIDWithStatusesDeployment,
 					tc.findOldestDeploymentForDeviceIDWithStatusesError,
 				)
-			// Add variadic arguments
-			for _, status := range model.ActiveDeploymentStatuses() {
-				call.Arguments = append(call.Arguments, status)
-			}
 
 			db.On("GetDeviceDeployment", ctx, tc.inputDeploymentId,
 				tc.inputDeviceId).Return(
@@ -313,16 +305,12 @@ func TestDecommissionDevice(t *testing.T) {
 				tc.inputDeploymentId, mock.AnythingOfType("model.DeviceDeploymentState")).Return(
 				tc.updateDeviceDeploymentStatusStatus, tc.updateDeviceDeploymentStatusError)
 
-			call = db.On("FindLatestDeploymentForDeviceIDWithStatuses",
+			db.On("FindLatestInactiveDeviceDeployment",
 				ctx, tc.inputDeviceId,
 			).Return(
 				tc.findLatestDeploymentForDeviceIDWithStatusesDeployment,
 				tc.findLatestDeploymentForDeviceIDWithStatusesError,
 			)
-			// Add variadic arguments
-			for _, status := range model.InactiveDeploymentStatuses() {
-				call.Arguments = append(call.Arguments, status)
-			}
 
 			db.On("FindNewerActiveDeployments", ctx, mock.AnythingOfType("*time.Time"),
 				0, 100).Return(
@@ -493,16 +481,12 @@ func TestAbortDeviceDeployments(t *testing.T) {
 			ctx := context.TODO()
 			db := mocks.DataStore{}
 
-			call := db.On("FindOldestDeploymentForDeviceIDWithStatuses",
+			db.On("FindOldestActiveDeviceDeployment",
 				ctx, tc.inputDeviceId).
 				Return(
 					tc.findOldestDeploymentForDeviceIDWithStatusesDeployment,
 					tc.findOldestDeploymentForDeviceIDWithStatusesError,
 				)
-			// Add variadic arguments
-			for _, status := range model.ActiveDeploymentStatuses() {
-				call.Arguments = append(call.Arguments, status)
-			}
 
 			db.On("GetDeviceDeployment", ctx, tc.inputDeploymentId,
 				tc.inputDeviceId).Return(
@@ -512,16 +496,12 @@ func TestAbortDeviceDeployments(t *testing.T) {
 				tc.inputDeploymentId, mock.AnythingOfType("model.DeviceDeploymentState")).Return(
 				tc.updateDeviceDeploymentStatusStatus, tc.updateDeviceDeploymentStatusError)
 
-			call = db.On("FindLatestDeploymentForDeviceIDWithStatuses",
+			db.On("FindLatestInactiveDeviceDeployment",
 				ctx, tc.inputDeviceId,
 			).Return(
 				tc.findLatestDeploymentForDeviceIDWithStatusesDeployment,
 				tc.findLatestDeploymentForDeviceIDWithStatusesError,
 			)
-			// Add variadic arguments
-			for _, status := range model.InactiveDeploymentStatuses() {
-				call.Arguments = append(call.Arguments, status)
-			}
 
 			db.On("FindNewerActiveDeployments", ctx, mock.AnythingOfType("*time.Time"),
 				0, 100).Return(

--- a/model/device_deployment.go
+++ b/model/device_deployment.go
@@ -251,6 +251,7 @@ func NewDeviceDeployment(deviceId, deploymentId string) *DeviceDeployment {
 	id := uid.String()
 
 	return &DeviceDeployment{
+		Active:         true,
 		Status:         DeviceDeploymentStatusPending,
 		DeviceId:       deviceId,
 		DeploymentId:   deploymentId,

--- a/model/device_deployment.go
+++ b/model/device_deployment.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -21,6 +21,12 @@ import (
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+)
+
+var (
+	ErrDeviceDeploymentStatusMismatch = errors.New(
+		"model active state does not match status",
+	)
 )
 
 // DeviceDeploymentStatus is an enumerated type showing the status of a device within a deployment
@@ -52,6 +58,9 @@ const (
 	DeviceDeploymentStatusDecommissioned
 	// DeviceDeploymentStatusNew = (DeviceDeploymentStatusSuccess +
 	// DeviceDeploymentStatusNoArtifact) / 2
+
+	DeviceDeploymentStatusActiveLow  = DeviceDeploymentStatusPauseBeforeInstall
+	DeviceDeploymentStatusActiveHigh = DeviceDeploymentStatusPending
 
 	DeviceDeploymentStatusFailureStr            = "failure"
 	DeviceDeploymentStatusAbortedStr            = "aborted"
@@ -173,6 +182,11 @@ func (stat *DeviceDeploymentStatus) UnmarshalText(b []byte) error {
 	return nil
 }
 
+func (stat DeviceDeploymentStatus) Active() bool {
+	return stat >= DeviceDeploymentStatusActiveLow &&
+		stat <= DeviceDeploymentStatusActiveHigh
+}
+
 // DeviceDeploymentStatus is a helper type for reporting status changes through
 // the layers
 type DeviceDeploymentState struct {
@@ -191,6 +205,10 @@ func (state DeviceDeploymentState) Validate() error {
 }
 
 type DeviceDeployment struct {
+	// Active says whether the device's deployment status is in an active
+	// state - in progress or pending.
+	Active bool `json:"-" bson:"active"`
+
 	// Internal field of initial creation of deployment
 	Created *time.Time `json:"created" bson:"created"`
 
@@ -243,13 +261,24 @@ func NewDeviceDeployment(deviceId, deploymentId string) *DeviceDeployment {
 }
 
 func (d DeviceDeployment) Validate() error {
-	return validation.ValidateStruct(&d,
+	err := validation.ValidateStruct(&d,
 		validation.Field(&d.Created, validation.Required),
-		validation.Field(&d.Status, validation.Required),
+		validation.Field(&d.Status, validation.Required, deviceDeploymentStatusValidator{}),
 		validation.Field(&d.DeviceId, validation.Required),
 		validation.Field(&d.DeploymentId, validation.Required, is.UUID),
 		validation.Field(&d.Id, validation.Required, is.UUID),
 	)
+	if err != nil {
+		return err
+	}
+	if d.Status.Active() {
+		if !d.Active {
+			return ErrDeviceDeploymentStatusMismatch
+		}
+	} else if d.Active {
+		return ErrDeviceDeploymentStatusMismatch
+	}
+	return nil
 }
 
 // Deployment statistics wrapper, each value carries a count of deployments

--- a/model/device_deployment_external_test.go
+++ b/model/device_deployment_external_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -105,22 +106,24 @@ func TestDeviceDeploymentValidate(t *testing.T) {
 		},
 	}
 
-	for _, test := range testCases {
+	for i := range testCases {
+		test := testCases[i]
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			dd := NewDeviceDeployment("", "")
 
-		dd := NewDeviceDeployment("", "")
+			dd.Created = test.InputCreated
+			dd.Id = test.InputID
+			dd.DeviceId = test.InputDeviceID
+			dd.DeploymentId = test.InputDeploymentID
 
-		dd.Created = test.InputCreated
-		dd.Id = test.InputID
-		dd.DeviceId = test.InputDeviceID
-		dd.DeploymentId = test.InputDeploymentID
+			err := dd.Validate()
 
-		err := dd.Validate()
-
-		if !test.IsValid {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
+			if !test.IsValid {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 
 }

--- a/model/validation.go
+++ b/model/validation.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -25,3 +25,11 @@ var (
 
 	lengthLessThan4096 = validation.Length(0, 4096)
 )
+
+type deviceDeploymentStatusValidator struct{}
+
+func (deviceDeploymentStatusValidator) Validate(v interface{}) error {
+	stat := v.(DeviceDeploymentStatus)
+	_, err := stat.MarshalText()
+	return err
+}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -66,12 +66,14 @@ type DataStore interface {
 		deployment ...*model.DeviceDeployment) error
 	ExistAssignedImageWithIDAndStatuses(ctx context.Context,
 		id string, statuses ...model.DeviceDeploymentStatus) (bool, error)
-	FindOldestDeploymentForDeviceIDWithStatuses(ctx context.Context,
-		deviceID string, statuses ...model.DeviceDeploymentStatus) (*model.DeviceDeployment, error)
-	FindLatestDeploymentForDeviceIDWithStatuses(ctx context.Context,
-		deviceID string, statuses ...model.DeviceDeploymentStatus) (*model.DeviceDeployment, error)
-	FindAllDeploymentsForDeviceIDWithStatuses(ctx context.Context,
-		deviceID string, statuses ...string) ([]model.DeviceDeployment, error)
+	FindOldestActiveDeviceDeployment(
+		ctx context.Context,
+		deviceID string,
+	) (*model.DeviceDeployment, error)
+	FindLatestInactiveDeviceDeployment(
+		ctx context.Context,
+		deviceID string,
+	) (*model.DeviceDeployment, error)
 	UpdateDeviceDeploymentStatus(
 		ctx context.Context,
 		deviceID string,

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -343,20 +343,13 @@ func (_m *DataStore) FindImageByID(ctx context.Context, id string) (*model.Image
 	return r0, r1
 }
 
-// FindLatestDeploymentForDeviceIDWithStatuses provides a mock function with given fields: ctx, deviceID, statuses
-func (_m *DataStore) FindLatestDeploymentForDeviceIDWithStatuses(ctx context.Context, deviceID string, statuses ...model.DeviceDeploymentStatus) (*model.DeviceDeployment, error) {
-	_va := make([]interface{}, len(statuses))
-	for _i := range statuses {
-		_va[_i] = statuses[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx, deviceID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// FindLatestInactiveDeviceDeployment provides a mock function with given fields: ctx, deviceID
+func (_m *DataStore) FindLatestInactiveDeviceDeployment(ctx context.Context, deviceID string) (*model.DeviceDeployment, error) {
+	ret := _m.Called(ctx, deviceID)
 
 	var r0 *model.DeviceDeployment
-	if rf, ok := ret.Get(0).(func(context.Context, string, ...model.DeviceDeploymentStatus) *model.DeviceDeployment); ok {
-		r0 = rf(ctx, deviceID, statuses...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.DeviceDeployment); ok {
+		r0 = rf(ctx, deviceID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.DeviceDeployment)
@@ -364,8 +357,8 @@ func (_m *DataStore) FindLatestDeploymentForDeviceIDWithStatuses(ctx context.Con
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, ...model.DeviceDeploymentStatus) error); ok {
-		r1 = rf(ctx, deviceID, statuses...)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, deviceID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -396,20 +389,13 @@ func (_m *DataStore) FindNewerActiveDeployments(ctx context.Context, createdAfte
 	return r0, r1
 }
 
-// FindOldestDeploymentForDeviceIDWithStatuses provides a mock function with given fields: ctx, deviceID, statuses
-func (_m *DataStore) FindOldestDeploymentForDeviceIDWithStatuses(ctx context.Context, deviceID string, statuses ...model.DeviceDeploymentStatus) (*model.DeviceDeployment, error) {
-	_va := make([]interface{}, len(statuses))
-	for _i := range statuses {
-		_va[_i] = statuses[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx, deviceID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// FindOldestActiveDeviceDeployment provides a mock function with given fields: ctx, deviceID
+func (_m *DataStore) FindOldestActiveDeviceDeployment(ctx context.Context, deviceID string) (*model.DeviceDeployment, error) {
+	ret := _m.Called(ctx, deviceID)
 
 	var r0 *model.DeviceDeployment
-	if rf, ok := ret.Get(0).(func(context.Context, string, ...model.DeviceDeploymentStatus) *model.DeviceDeployment); ok {
-		r0 = rf(ctx, deviceID, statuses...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.DeviceDeployment); ok {
+		r0 = rf(ctx, deviceID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.DeviceDeployment)
@@ -417,8 +403,8 @@ func (_m *DataStore) FindOldestDeploymentForDeviceIDWithStatuses(ctx context.Con
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, ...model.DeviceDeploymentStatus) error); ok {
-		r1 = rf(ctx, deviceID, statuses...)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, deviceID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -671,3 +671,286 @@ func TestSortDeployments(t *testing.T) {
 	assert.Equal(t, deploymentsQty, count)
 	assert.Equal(t, deploymentTwoID, deployments[0].Id)
 }
+
+func TestFindOldestActiveDeviceDeployment(t *testing.T) {
+	db.Wipe()
+	const (
+		TenantID       = "123456789012345678901234"
+		TenantDeviceID = "27d5d258-b880-4157-8eb7-8d68aeb1663d"
+		DeviceID       = "1140bc78-b898-4b2a-a4a2-551cb7bd9ac8"
+	)
+	// Initialize dataset
+	ds := NewDataStoreMongoWithClient(db.Client())
+	now := time.Now()
+	for _, env := range []struct {
+		tenantID string
+		deviceID string
+	}{
+		{tenantID: TenantID, deviceID: TenantDeviceID},
+		{deviceID: DeviceID},
+	} {
+		ctx := context.Background()
+		if env.tenantID != "" {
+			ctx = identity.WithContext(ctx, &identity.Identity{
+				Tenant: env.tenantID,
+			})
+		}
+		if err := ds.ProvisionTenant(ctx, env.tenantID); err != nil {
+			panic(err)
+		}
+		for _, depl := range []*model.DeviceDeployment{{
+			Id: "0",
+			Created: func() *time.Time {
+				ret := now.Add(-2 * time.Hour)
+				return &ret
+			}(),
+			Status:       model.DeviceDeploymentStatusSuccess,
+			DeviceId:     env.deviceID,
+			DeploymentId: uuid.New().String(),
+		}, {
+			Id: "1",
+			Created: func() *time.Time {
+				ret := now.Add(-3 * time.Hour / 2)
+				return &ret
+			}(),
+			Status:       model.DeviceDeploymentStatusAlreadyInst,
+			DeviceId:     env.deviceID,
+			DeploymentId: uuid.New().String(),
+		}, {
+			Id: "2",
+			Created: func() *time.Time {
+				ret := now.Add(-time.Hour)
+				return &ret
+			}(),
+			Status:       model.DeviceDeploymentStatusDownloading,
+			DeviceId:     env.deviceID,
+			DeploymentId: uuid.New().String(),
+			Active:       true,
+		}, {
+			Id: "3",
+			Created: func() *time.Time {
+				ret := now.Add(-time.Minute)
+				return &ret
+			}(),
+			Status:       model.DeviceDeploymentStatusPending,
+			DeviceId:     env.deviceID,
+			DeploymentId: uuid.New().String(),
+			Active:       true,
+		}} {
+			if err := ds.InsertDeviceDeployment(ctx, depl); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	testCases := []struct {
+		Name string
+
+		CTX      context.Context
+		TenantID string
+		DeviceID string
+
+		ExpectedID *string
+		Error      error
+	}{{
+		Name: "ok",
+
+		CTX:      context.Background(),
+		DeviceID: DeviceID,
+
+		ExpectedID: func() *string { s := "2"; return &s }(),
+	}, {
+		Name: "ok, multi-tenant mode",
+
+		CTX: identity.WithContext(context.Background(), &identity.Identity{
+			Tenant: TenantID,
+		}),
+		DeviceID: TenantDeviceID,
+
+		ExpectedID: func() *string { s := "2"; return &s }(),
+	}, {
+		Name: "ok, no document",
+
+		CTX: identity.WithContext(context.Background(), &identity.Identity{
+			Tenant: TenantID,
+		}),
+		DeviceID: DeviceID, // NOTE: We're using the tenant database
+	}, {
+		Name: "error, context canceled",
+
+		CTX: func() context.Context {
+			ctx, ccl := context.WithCancel(context.Background())
+			ccl()
+			return ctx
+		}(),
+		DeviceID: DeviceID, // NOTE: We're using the tenant database
+
+		Error: context.Canceled,
+	}, {
+		Name:  "error, empty device id",
+		Error: ErrStorageInvalidID,
+	}}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			d, err := ds.FindOldestActiveDeviceDeployment(tc.CTX, tc.DeviceID)
+			if tc.Error != nil {
+				if assert.Error(t, err) {
+					assert.Regexp(t, tc.Error.Error(), err.Error())
+				}
+			} else {
+				if assert.NoError(t, err) {
+					if tc.ExpectedID != nil && assert.NotNil(t, d) {
+						assert.Equal(t, *tc.ExpectedID, d.Id,
+							"did not receive the expected device deployment id",
+						)
+					} else {
+						assert.Nil(t, d, "did not expect to find a deployment")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFindLatestInactiveDeviceDeployment(t *testing.T) {
+	db.Wipe()
+	const (
+		TenantID       = "123456789012345678901234"
+		TenantDeviceID = "27d5d258-b880-4157-8eb7-8d68aeb1663d"
+		DeviceID       = "1140bc78-b898-4b2a-a4a2-551cb7bd9ac8"
+	)
+	// Initialize dataset
+	ds := NewDataStoreMongoWithClient(db.Client())
+	now := time.Now()
+	for _, env := range []struct {
+		tenantID string
+		deviceID string
+	}{
+		{tenantID: TenantID, deviceID: TenantDeviceID},
+		{deviceID: DeviceID},
+	} {
+		ctx := context.Background()
+		if env.tenantID != "" {
+			ctx = identity.WithContext(ctx, &identity.Identity{
+				Tenant: env.tenantID,
+			})
+		}
+		if err := ds.ProvisionTenant(ctx, env.tenantID); err != nil {
+			panic(err)
+		}
+		for _, depl := range []*model.DeviceDeployment{{
+			Id: "0",
+			Created: func() *time.Time {
+				ret := now.Add(-2 * time.Hour)
+				return &ret
+			}(),
+			Status:       model.DeviceDeploymentStatusSuccess,
+			DeviceId:     env.deviceID,
+			DeploymentId: uuid.New().String(),
+		}, {
+			Id: "1",
+			Created: func() *time.Time {
+				ret := now.Add(-3 * time.Hour / 2)
+				return &ret
+			}(),
+			Status:       model.DeviceDeploymentStatusAlreadyInst,
+			DeviceId:     env.deviceID,
+			DeploymentId: uuid.New().String(),
+		}, {
+			Id: "2",
+			Created: func() *time.Time {
+				ret := now.Add(-time.Hour)
+				return &ret
+			}(),
+			Status:       model.DeviceDeploymentStatusDownloading,
+			DeviceId:     env.deviceID,
+			DeploymentId: uuid.New().String(),
+			Active:       true,
+		}, {
+			Id: "3",
+			Created: func() *time.Time {
+				ret := now.Add(-time.Minute)
+				return &ret
+			}(),
+			Status:       model.DeviceDeploymentStatusPending,
+			DeviceId:     env.deviceID,
+			DeploymentId: uuid.New().String(),
+			Active:       true,
+		}} {
+			if err := ds.InsertDeviceDeployment(ctx, depl); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	testCases := []struct {
+		Name string
+
+		CTX      context.Context
+		TenantID string
+		DeviceID string
+
+		ExpectedID *string
+		Error      error
+	}{{
+		Name: "ok",
+
+		CTX:      context.Background(),
+		DeviceID: DeviceID,
+
+		ExpectedID: func() *string { s := "1"; return &s }(),
+	}, {
+		Name: "ok, multi-tenant mode",
+
+		CTX: identity.WithContext(context.Background(), &identity.Identity{
+			Tenant: TenantID,
+		}),
+		DeviceID: TenantDeviceID,
+
+		ExpectedID: func() *string { s := "1"; return &s }(),
+	}, {
+		Name: "ok, no document",
+
+		CTX: identity.WithContext(context.Background(), &identity.Identity{
+			Tenant: TenantID,
+		}),
+		DeviceID: DeviceID, // NOTE: We're using the tenant database
+	}, {
+		Name: "error, context canceled",
+
+		CTX: func() context.Context {
+			ctx, ccl := context.WithCancel(context.Background())
+			ccl()
+			return ctx
+		}(),
+		DeviceID: DeviceID, // NOTE: We're using the tenant database
+
+		Error: context.Canceled,
+	}, {
+		Name:  "error, empty device id",
+		Error: ErrStorageInvalidID,
+	}}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			d, err := ds.FindLatestInactiveDeviceDeployment(tc.CTX, tc.DeviceID)
+			if tc.Error != nil {
+				if assert.Error(t, err) {
+					assert.Regexp(t, tc.Error.Error(), err.Error())
+				}
+			} else {
+				if assert.NoError(t, err) {
+					if tc.ExpectedID != nil && assert.NotNil(t, d) {
+						assert.Equal(t, *tc.ExpectedID, d.Id,
+							"did not receive the expected device deployment id",
+						)
+					} else {
+						assert.Nil(t, d, "did not expect to find a deployment")
+					}
+				}
+			}
+		})
+	}
+}

--- a/store/mongo/device_deployments_test.go
+++ b/store/mongo/device_deployments_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -464,6 +464,7 @@ func newDeviceDeploymentWithStatus(t *testing.T, deviceID string, deploymentID s
 	d := model.NewDeviceDeployment(deviceID, deploymentID)
 
 	d.Status = status
+	d.Active = status.Active()
 	return d
 }
 

--- a/store/mongo/migration_1_2_9.go
+++ b/store/mongo/migration_1_2_9.go
@@ -15,8 +15,10 @@ package mongo
 
 import (
 	"context"
+	"strings"
 
 	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 
@@ -28,10 +30,56 @@ type migration_1_2_9 struct {
 	db     string
 }
 
-func (m *migration_1_2_9) Up(from migrate.Version) error {
+func (m *migration_1_2_9) Up(from migrate.Version) (err error) {
+	const (
+		DBNameAdmin       = "admin"
+		CollNameMigration = CollectionDevices + "-1_2_9"
+	)
+	var (
+		CollNamespaceSrc = strings.Join([]string{m.db, CollectionDevices}, ".")
+		CollNamespaceTmp = strings.Join([]string{m.db, CollNameMigration}, ".")
+	)
 	ctx := context.Background()
 	storage := NewDataStoreMongoWithClient(m.client)
-	collDev := storage.client.Database(m.db).Collection(CollectionDevices)
+	database := storage.client.Database(m.db)
+
+	// Rename the collection such that no writes propagate to the
+	// collection under migration.
+	// The first step is to allow reentrant executions of the migration.
+	cur, err := database.ListCollections(ctx, bson.D{{Key: "name", Value: CollNameMigration}})
+	if err != nil {
+		return errors.Wrap(err, "failed to list collection names")
+	}
+	if !cur.Next(ctx) {
+		err = storage.client.
+			Database(DBNameAdmin).
+			RunCommand(ctx, bson.D{
+				{Key: "renameCollection", Value: CollNamespaceSrc},
+				{Key: "to", Value: CollNamespaceTmp},
+				{Key: "dropTarget", Value: false},
+				{Key: "comment", Value: "Freeze collection for migration 1.2.9"},
+			}).Err()
+		if err != nil {
+			return errors.Wrap(err, "failed to freeze collection")
+		}
+	}
+	defer func() {
+		errRestore := storage.client.
+			Database(DBNameAdmin).
+			RunCommand(ctx, bson.D{
+				{Key: "renameCollection", Value: CollNamespaceTmp},
+				{Key: "to", Value: CollNamespaceSrc},
+				{Key: "dropTarget", Value: true},
+				{Key: "comment", Value: "Thaw collection for migration 1.2.9"},
+			}).Err()
+		if err == nil {
+			err = errRestore
+		} else {
+			err = errors.Wrapf(err, "failed to restore collection: %s", errRestore)
+		}
+	}()
+	collDev := storage.client.Database(m.db).Collection(CollNameMigration)
+
 	bulkReqs := []mongo.WriteModel{
 		mongo.NewUpdateManyModel().
 			SetFilter(bson.D{{
@@ -61,7 +109,7 @@ func (m *migration_1_2_9) Up(from migrate.Version) error {
 				Key: StorageKeyDeviceDeploymentActive, Value: false,
 			}}}}),
 	}
-	_, err := collDev.BulkWrite(ctx, bulkReqs)
+	_, err = collDev.BulkWrite(ctx, bulkReqs)
 	if err == nil {
 		err = storage.EnsureIndexes(m.db, CollectionDevices,
 			IndexDeviceDeploymentsActiveCreatedModel,

--- a/store/mongo/migration_1_2_9.go
+++ b/store/mongo/migration_1_2_9.go
@@ -1,0 +1,75 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/mendersoftware/deployments/model"
+)
+
+type migration_1_2_9 struct {
+	client *mongo.Client
+	db     string
+}
+
+func (m *migration_1_2_9) Up(from migrate.Version) error {
+	ctx := context.Background()
+	storage := NewDataStoreMongoWithClient(m.client)
+	collDev := storage.client.Database(m.db).Collection(CollectionDevices)
+	bulkReqs := []mongo.WriteModel{
+		mongo.NewUpdateManyModel().
+			SetFilter(bson.D{{
+				Key: StorageKeyDeviceDeploymentStatus, Value: bson.D{{
+					Key: "$lt", Value: model.DeviceDeploymentStatusActiveLow,
+				}},
+			}}).
+			SetUpdate(bson.D{{Key: "$set", Value: bson.D{{
+				Key: StorageKeyDeviceDeploymentActive, Value: false,
+			}}}}),
+		mongo.NewUpdateManyModel().
+			SetFilter(bson.D{{
+				Key: StorageKeyDeviceDeploymentStatus, Value: bson.D{
+					{Key: "$gte", Value: model.DeviceDeploymentStatusActiveLow},
+					{Key: "$lte", Value: model.DeviceDeploymentStatusActiveHigh},
+				},
+			}}).SetUpdate(bson.D{{Key: "$set", Value: bson.D{{
+			Key: StorageKeyDeviceDeploymentActive, Value: true,
+		}}}}),
+		mongo.NewUpdateManyModel().
+			SetFilter(bson.D{{
+				Key: StorageKeyDeviceDeploymentStatus, Value: bson.D{{
+					Key: "$gt", Value: model.DeviceDeploymentStatusActiveHigh,
+				}},
+			}}).
+			SetUpdate(bson.D{{Key: "$set", Value: bson.D{{
+				Key: StorageKeyDeviceDeploymentActive, Value: false,
+			}}}}),
+	}
+	_, err := collDev.BulkWrite(ctx, bulkReqs)
+	if err == nil {
+		err = storage.EnsureIndexes(m.db, CollectionDevices,
+			IndexDeviceDeploymentsActiveCreatedModel,
+		)
+	}
+	return err
+}
+
+func (m *migration_1_2_9) Version() migrate.Version {
+	return migrate.MakeVersion(1, 2, 9)
+}

--- a/store/mongo/migration_1_2_9_test.go
+++ b/store/mongo/migration_1_2_9_test.go
@@ -1,0 +1,204 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package mongo
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/mendersoftware/deployments/model"
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// capped version of the device deployment document
+type DeviceDeployment1_2_8 struct {
+	ID             string                       `bson:"_id"`
+	DeviceID       string                       `bson:"deviceid"`
+	Status         model.DeviceDeploymentStatus `bson:"status"`
+	Created        time.Time                    `bson:"created"`
+	ExpectedActive bool                         `bson:"-"`
+}
+
+func TestMigration_1_2_9(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestMigration_1_2_9 in short mode.")
+	}
+	ctx := context.Background()
+
+	now := time.Now()
+	dataSet := []interface{}{
+		DeviceDeployment1_2_8{
+			ID:       "0",
+			DeviceID: "1",
+			Status:   model.DeviceDeploymentStatusAborted,
+			Created:  now.Add(-time.Hour),
+		},
+		DeviceDeployment1_2_8{
+			ID:             "1",
+			DeviceID:       "1",
+			Status:         model.DeviceDeploymentStatusPending,
+			Created:        now.Add(-time.Hour / 2),
+			ExpectedActive: true,
+		},
+		DeviceDeployment1_2_8{
+			ID:             "2",
+			DeviceID:       "1",
+			Status:         model.DeviceDeploymentStatusDownloading,
+			Created:        now.Add(-time.Hour / 4),
+			ExpectedActive: true,
+		},
+		DeviceDeployment1_2_8{
+			ID:       "3",
+			DeviceID: "1",
+			Status:   model.DeviceDeploymentStatusSuccess,
+			Created:  now.Add(-time.Minute),
+		},
+		DeviceDeployment1_2_8{
+			ID:       "4",
+			DeviceID: "1",
+			Status:   model.DeviceDeploymentStatusDecommissioned,
+			Created:  now.Add(-time.Minute),
+		},
+	}
+
+	// TODO: Test schema migration!
+
+	testCases := map[string]struct {
+		// ST or MT naming convention
+		db    string
+		dbVer string
+
+		err error
+	}{
+		"ST, from 1.2.8": {
+			db:    "deployments_service",
+			dbVer: "1.2.8",
+		},
+		"MT, from 1.2.8": {
+			db:    "deployments_service-59afdb71c704db002a86ad95",
+			dbVer: "1.2.8",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			db.Wipe()
+			c := db.Client()
+
+			// setup existing migrations
+			if tc.dbVer != "" {
+				ver, err := migrate.NewVersion(tc.dbVer)
+				assert.NoError(t, err)
+				migrate.UpdateMigrationInfo(db.CTX(), *ver, c, tc.db)
+			}
+
+			collDevs := c.Database(tc.db).
+				Collection(CollectionDevices)
+			collDevs.InsertMany(ctx, dataSet)
+
+			migrations := []migrate.Migration{
+				&migration_1_2_9{
+					client: c,
+					db:     tc.db,
+				},
+			}
+
+			m := migrate.SimpleMigrator{
+				Client:      c,
+				Db:          tc.db,
+				Automigrate: true,
+			}
+
+			err := m.Apply(ctx, migrate.MakeVersion(1, 2, 9), migrations)
+			assert.NoError(t, err)
+
+			cur, err := collDevs.Find(ctx, bson.D{})
+			if err != nil {
+				panic(err)
+			}
+			for cur.Next(ctx) {
+				var item struct {
+					ID     string `bson:"id"`
+					Active *bool  `bson:"active"`
+				}
+				err := cur.Decode(&item)
+				if err != nil {
+					panic(err)
+				}
+				if assert.NotNilf(t,
+					item.Active,
+					"'active' field is not set for document with _id: '%s'",
+					item.ID) {
+					continue
+				}
+				i, err := strconv.Atoi(item.ID)
+				if err != nil {
+					panic(err)
+				} else if i >= len(dataSet) || i < 0 {
+					panic("document index out of bounds")
+				}
+				assert.Equal(t,
+					dataSet[i].(DeviceDeployment1_2_8).ExpectedActive,
+					*item.Active,
+				)
+
+			}
+
+			// verify new indexes are present
+			cursor, err := collDevs.
+				Indexes().
+				List(ctx)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			expectedIndexes := map[string]bson.D{
+				IndexDeviceDeploymentsActiveCreated: {
+					{Key: StorageKeyDeviceDeploymentActive, Value: int32(1)},
+					{Key: StorageKeyDeviceDeploymentDeviceId, Value: int32(1)},
+					{Key: StorageKeyDeviceDeploymentCreated, Value: int32(1)},
+				},
+			}
+
+			for cursor.Next(ctx) {
+				var idx struct {
+					Name string `bson:"name"`
+					Key  bson.D `bson:"key"`
+				}
+				err = cursor.Decode(&idx)
+				if err != nil {
+					panic(err)
+				}
+				if idx.Name == "_id_" {
+					// Skip the default index
+					continue
+				}
+
+				if assert.Containsf(t,
+					expectedIndexes, idx.Name,
+					"Found an unexpected index '%s'", idx.Name,
+				) {
+					assert.EqualValues(t,
+						expectedIndexes[idx.Name], idx.Key,
+						"Index keys did not match expectations",
+					)
+				}
+			}
+		})
+	}
+}

--- a/store/mongo/migrations.go
+++ b/store/mongo/migrations.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	DbVersion = "1.2.8"
+	DbVersion = "1.2.9"
 	DbName    = "deployment_service"
 )
 
@@ -110,6 +110,10 @@ func MigrateSingle(ctx context.Context,
 			db:     db,
 		},
 		&migration_1_2_8{
+			client: client,
+			db:     db,
+		},
+		&migration_1_2_9{
 			client: client,
 			db:     db,
 		},


### PR DESCRIPTION
Introduces a new schema migration to the device collection adding an
'active' field and an appropriate index for a direct query on the latest
DeviceDeployment document.
NOTE: This migration requires shutting down the service!