### PR TITLE
fix: fix error handling in the deployments/next handler

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -1224,7 +1224,23 @@ func (d *DeploymentsApiHandlers) GetDeploymentForDevice(w rest.ResponseWriter, r
 		return
 	}
 
-	deployment, err := d.app.GetDeploymentForDeviceWithCurrent(ctx, idata.Subject, installed)
+	request := &model.DeploymentNextRequest{
+		DeviceProvides: installed,
+	}
+
+	d.getDeploymentForDevice(w, r, idata, request)
+}
+
+func (d *DeploymentsApiHandlers) getDeploymentForDevice(
+	w rest.ResponseWriter,
+	r *rest.Request,
+	idata *identity.Identity,
+	request *model.DeploymentNextRequest,
+) {
+	ctx := r.Context()
+	l := requestlog.GetRequestLogger(r)
+
+	deployment, err := d.app.GetDeploymentForDeviceWithCurrent(ctx, idata.Subject, request)
 	if err != nil {
 		if err == app.ErrConflictingRequestData {
 			d.view.RenderError(w, r, err, http.StatusConflict, l)
@@ -1253,7 +1269,7 @@ func (d *DeploymentsApiHandlers) GetDeploymentForDevice(w rest.ResponseWriter, r
 			http.MethodGet,
 			FMTConfigURL(
 				d.config.PresignScheme, hostName,
-				deployment.ID, installed.DeviceType,
+				deployment.ID, request.DeviceProvides.DeviceType,
 				idata.Subject,
 			),
 			nil,

--- a/api/http/api_deployments_test.go
+++ b/api/http/api_deployments_test.go
@@ -998,9 +998,11 @@ func TestGetDeploymentForDevice(t *testing.T) {
 			app.On("GetDeploymentForDeviceWithCurrent",
 				contextMatcher(),
 				uuid.NewSHA1(uuid.NameSpaceOID, []byte("device")).String(),
-				&model.InstalledDeviceDeployment{
-					ArtifactName: "bagelOS1.0.1",
-					DeviceType:   "bagelShins",
+				&model.DeploymentNextRequest{
+					DeviceProvides: &model.InstalledDeviceDeployment{
+						ArtifactName: "bagelOS1.0.1",
+						DeviceType:   "bagelShins",
+					},
 				},
 			).Return(&model.DeploymentInstructions{
 				ID: uuid.NewSHA1(uuid.NameSpaceURL, []byte("deployment")).String(),
@@ -1043,9 +1045,11 @@ func TestGetDeploymentForDevice(t *testing.T) {
 			app.On("GetDeploymentForDeviceWithCurrent",
 				contextMatcher(),
 				uuid.NewSHA1(uuid.NameSpaceOID, []byte("device")).String(),
-				&model.InstalledDeviceDeployment{
-					ArtifactName: "bagelOS1.0.1",
-					DeviceType:   "bagelBone",
+				&model.DeploymentNextRequest{
+					DeviceProvides: &model.InstalledDeviceDeployment{
+						ArtifactName: "bagelOS1.0.1",
+						DeviceType:   "bagelBone",
+					},
 				},
 			).Return(&model.DeploymentInstructions{
 				ID: uuid.NewSHA1(uuid.NameSpaceURL, []byte("deployment")).String(),
@@ -1084,9 +1088,11 @@ func TestGetDeploymentForDevice(t *testing.T) {
 			app.On("GetDeploymentForDeviceWithCurrent",
 				contextMatcher(),
 				uuid.NewSHA1(uuid.NameSpaceOID, []byte("device")).String(),
-				&model.InstalledDeviceDeployment{
-					ArtifactName: "bagelOS1.0.1",
-					DeviceType:   "bagelShins",
+				&model.DeploymentNextRequest{
+					DeviceProvides: &model.InstalledDeviceDeployment{
+						ArtifactName: "bagelOS1.0.1",
+						DeviceType:   "bagelShins",
+					},
 				},
 			).Return(&model.DeploymentInstructions{
 				ID: uuid.NewSHA1(uuid.NameSpaceURL, []byte("deployment")).String(),
@@ -1125,9 +1131,11 @@ func TestGetDeploymentForDevice(t *testing.T) {
 
 				contextMatcher(),
 				uuid.NewSHA1(uuid.NameSpaceOID, []byte("device")).String(),
-				&model.InstalledDeviceDeployment{
-					ArtifactName: "bagelOS1.0.1",
-					DeviceType:   "bagelShins",
+				&model.DeploymentNextRequest{
+					DeviceProvides: &model.InstalledDeviceDeployment{
+						ArtifactName: "bagelOS1.0.1",
+						DeviceType:   "bagelShins",
+					},
 				},
 			).Return(&model.DeploymentInstructions{
 				ID: uuid.NewSHA1(uuid.NameSpaceURL, []byte("deployment")).String(),
@@ -1168,9 +1176,11 @@ func TestGetDeploymentForDevice(t *testing.T) {
 
 				contextMatcher(),
 				uuid.NewSHA1(uuid.NameSpaceOID, []byte("device")).String(),
-				&model.InstalledDeviceDeployment{
-					ArtifactName: "bagelOS1.0.1",
-					DeviceType:   "bagelShins",
+				&model.DeploymentNextRequest{
+					DeviceProvides: &model.InstalledDeviceDeployment{
+						ArtifactName: "bagelOS1.0.1",
+						DeviceType:   "bagelShins",
+					},
 				},
 			).Return(&model.DeploymentInstructions{
 				ID: uuid.NewSHA1(uuid.NameSpaceURL, []byte("deployment")).String(),
@@ -1210,9 +1220,11 @@ func TestGetDeploymentForDevice(t *testing.T) {
 
 				contextMatcher(),
 				uuid.NewSHA1(uuid.NameSpaceOID, []byte("device")).String(),
-				&model.InstalledDeviceDeployment{
-					ArtifactName: "bagelOS1.0.1",
-					DeviceType:   "bagelShins",
+				&model.DeploymentNextRequest{
+					DeviceProvides: &model.InstalledDeviceDeployment{
+						ArtifactName: "bagelOS1.0.1",
+						DeviceType:   "bagelShins",
+					},
 				},
 			).Return(&model.DeploymentInstructions{
 				ID: uuid.NewSHA1(uuid.NameSpaceURL, []byte("deployment")).String(),
@@ -1307,9 +1319,11 @@ func TestGetDeploymentForDevice(t *testing.T) {
 
 				contextMatcher(),
 				uuid.NewSHA1(uuid.NameSpaceOID, []byte("device")).String(),
-				&model.InstalledDeviceDeployment{
-					ArtifactName: "bagelOS1.0.1",
-					DeviceType:   "bagelShins",
+				&model.DeploymentNextRequest{
+					DeviceProvides: &model.InstalledDeviceDeployment{
+						ArtifactName: "bagelOS1.0.1",
+						DeviceType:   "bagelShins",
+					},
 				},
 			).Return(nil, errors.New("mongo: internal error"))
 			return app
@@ -1340,9 +1354,11 @@ func TestGetDeploymentForDevice(t *testing.T) {
 
 				contextMatcher(),
 				uuid.NewSHA1(uuid.NameSpaceOID, []byte("device")).String(),
-				&model.InstalledDeviceDeployment{
-					ArtifactName: "bagelOS1.0.1",
-					DeviceType:   "bagelShins",
+				&model.DeploymentNextRequest{
+					DeviceProvides: &model.InstalledDeviceDeployment{
+						ArtifactName: "bagelOS1.0.1",
+						DeviceType:   "bagelShins",
+					},
 				},
 			).Return(nil, nil)
 			return app

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -264,13 +264,13 @@ func (_m *App) GetDeployment(ctx context.Context, deploymentID string) (*model.D
 	return r0, r1
 }
 
-// GetDeploymentForDeviceWithCurrent provides a mock function with given fields: ctx, deviceID, current
-func (_m *App) GetDeploymentForDeviceWithCurrent(ctx context.Context, deviceID string, current *model.InstalledDeviceDeployment) (*model.DeploymentInstructions, error) {
-	ret := _m.Called(ctx, deviceID, current)
+// GetDeploymentForDeviceWithCurrent provides a mock function with given fields: ctx, deviceID, request
+func (_m *App) GetDeploymentForDeviceWithCurrent(ctx context.Context, deviceID string, request *model.DeploymentNextRequest) (*model.DeploymentInstructions, error) {
+	ret := _m.Called(ctx, deviceID, request)
 
 	var r0 *model.DeploymentInstructions
-	if rf, ok := ret.Get(0).(func(context.Context, string, *model.InstalledDeviceDeployment) *model.DeploymentInstructions); ok {
-		r0 = rf(ctx, deviceID, current)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *model.DeploymentNextRequest) *model.DeploymentInstructions); ok {
+		r0 = rf(ctx, deviceID, request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.DeploymentInstructions)
@@ -278,8 +278,8 @@ func (_m *App) GetDeploymentForDeviceWithCurrent(ctx context.Context, deviceID s
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, *model.InstalledDeviceDeployment) error); ok {
-		r1 = rf(ctx, deviceID, current)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *model.DeploymentNextRequest) error); ok {
+		r1 = rf(ctx, deviceID, request)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/app/status_test.go
+++ b/app/status_test.go
@@ -105,9 +105,11 @@ func TestGetDeploymentForDeviceWithCurrent(t *testing.T) {
 	depName := "foo"
 	depArtifact := "bar"
 
-	installed := model.InstalledDeviceDeployment{
-		ArtifactName: depArtifact,
-		DeviceType:   devType,
+	request := &model.DeploymentNextRequest{
+		DeviceProvides: &model.InstalledDeviceDeployment{
+			ArtifactName: depArtifact,
+			DeviceType:   devType,
+		},
 	}
 
 	fakeDeployment, err := model.NewDeploymentFromConstructor(
@@ -166,9 +168,13 @@ func TestGetDeploymentForDeviceWithCurrent(t *testing.T) {
 		model.DeploymentStatusFinished,
 		mock.AnythingOfType("time.Time")).Return(nil)
 
+	db.On("SaveDeviceDeploymentRequest", ctx,
+		mock.AnythingOfType("string"),
+		request).Return(nil)
+
 	ds := NewDeployments(&db, fs, "")
 
-	_, err = ds.GetDeploymentForDeviceWithCurrent(ctx, devId, &installed)
+	_, err = ds.GetDeploymentForDeviceWithCurrent(ctx, devId, request)
 	assert.NoError(t, err)
 }
 

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -87,7 +87,6 @@ type DataStore interface {
 		deviceID string,
 		deploymentID string,
 		artifact *model.Image,
-		installed *model.InstalledDeviceDeployment,
 	) error
 	AggregateDeviceDeploymentByStatus(ctx context.Context,
 		id string) (model.Stats, error)
@@ -103,6 +102,11 @@ type DataStore interface {
 	DecommissionDeviceDeployments(ctx context.Context, deviceId string) error
 	GetDeviceDeployment(ctx context.Context,
 		deploymentID string, deviceID string) (*model.DeviceDeployment, error)
+	SaveDeviceDeploymentRequest(
+		ctx context.Context,
+		ID string,
+		request *model.DeploymentNextRequest,
+	) error
 
 	// deployments
 	InsertDeployment(ctx context.Context, deployment *model.Deployment) error

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -69,13 +69,13 @@ func (_m *DataStore) AggregateDeviceDeploymentByStatus(ctx context.Context, id s
 	return r0, r1
 }
 
-// AssignArtifact provides a mock function with given fields: ctx, deviceID, deploymentID, artifact, installed
-func (_m *DataStore) AssignArtifact(ctx context.Context, deviceID string, deploymentID string, artifact *model.Image, installed *model.InstalledDeviceDeployment) error {
-	ret := _m.Called(ctx, deviceID, deploymentID, artifact, installed)
+// AssignArtifact provides a mock function with given fields: ctx, deviceID, deploymentID, artifact
+func (_m *DataStore) AssignArtifact(ctx context.Context, deviceID string, deploymentID string, artifact *model.Image) error {
+	ret := _m.Called(ctx, deviceID, deploymentID, artifact)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, *model.Image, *model.InstalledDeviceDeployment) error); ok {
-		r0 = rf(ctx, deviceID, deploymentID, artifact, installed)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, *model.Image) error); ok {
+		r0 = rf(ctx, deviceID, deploymentID, artifact)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -884,6 +884,20 @@ func (_m *DataStore) SaveDeviceDeploymentLog(ctx context.Context, log model.Depl
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, model.DeploymentLog) error); ok {
 		r0 = rf(ctx, log)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SaveDeviceDeploymentRequest provides a mock function with given fields: ctx, ID, request
+func (_m *DataStore) SaveDeviceDeploymentRequest(ctx context.Context, ID string, request *model.DeploymentNextRequest) error {
+	ret := _m.Called(ctx, ID, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *model.DeploymentNextRequest) error); ok {
+		r0 = rf(ctx, ID, request)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
PR includes a fix for error handling in the deployments/next handler, but it also unifies device deployment request model, between OS and Enterprise versions of the service (https://tracker.mender.io/browse/MEN-5597)