### PR TITLE
MEN-5602 and MEN-5599

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1412,7 +1412,9 @@ func (d *Deployments) UpdateDeviceDeploymentStatus(ctx context.Context, deployme
 	}
 
 	dd, err := d.db.GetDeviceDeployment(ctx, deploymentID, deviceID)
-	if err != nil {
+	if err == mongo.ErrStorageNotFound {
+		return ErrStorageNotFound
+	} else if err != nil {
 		return err
 	}
 

--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -259,7 +259,7 @@ definitions:
     properties:
       id:
         type: string
-        description: Deployment ID (device unique)
+        description: Deployment ID
       artifact:
         type: object
         properties:


### PR DESCRIPTION
fix: return 404 instead of 500 when a device updates non-existent deployments
fix(docs): DeploymentInstructions's id property is not device unique

Depends on: https://github.com/mendersoftware/integration/pull/2015