### PR TITLE
feat(bootstrap-artifact): Support for empty Artifacts

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -823,7 +823,7 @@ func getMetaFromArchive(r *io.Reader) (*model.ArtifactMeta, error) {
 			metaArtifact.Updates,
 			model.Update{
 				TypeInfo: model.ArtifactUpdateTypeInfo{
-					Type: *p.GetUpdateType(),
+					Type: p.GetUpdateType(),
 				},
 				Files:    uFiles,
 				MetaData: uMetadata,

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -1569,6 +1569,7 @@ definitions:
       properties:
         type:
           type: string
+          description: Note that for emtpy Artifacts, the type is 'null'
   UpdateFile:
       description: |
           Information about particular update file.

--- a/model/update.go
+++ b/model/update.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import "time"
 
 // Type info structure
 type ArtifactUpdateTypeInfo struct {
-	Type string `json:"type" valid:"required"`
+	Type *string `json:"type" valid:"required"`
 }
 
 // Update file structure

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -194,12 +194,34 @@ class ArtifactsClient(SwaggerApiClient):
         # delete it now (NOTE: not using bravado as bravado does not support
         # DELETE)
         rsp = requests.delete(
-            self.make_api_url("/artifacts/{}".format(artid)), verify=False
+            self.make_api_url(f"/artifacts/{artid}"), verify=False
         )
         try:
             assert rsp.status_code == 204
         except AssertionError:
             raise ArtifactsClientError("delete failed", rsp)
+
+    def list_artifacts(self):
+        # List artifacts. For use in tests that cannot use bravado
+        rsp = requests.get(
+            self.make_api_url("/artifacts"), verify=False
+        )
+        try:
+            assert rsp.status_code == 200
+        except AssertionError:
+            raise ArtifactsClientError("get failed", rsp)
+        return rsp
+
+    def show_artifact(self, artid=""):
+        # Show artifact. For use in tests that cannot use bravado
+        rsp = requests.get(
+            self.make_api_url(f"/artifacts/{artid}"), verify=False
+        )
+        try:
+            assert rsp.status_code == 200
+        except AssertionError:
+            raise ArtifactsClientError("get failed", rsp)
+        return rsp
 
     @contextmanager
     def with_added_artifact(self, description="", size=0, data=None):

--- a/tests/tests/test_api_internal.py
+++ b/tests/tests/test_api_internal.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ from uuid import uuid4
 from bson.objectid import ObjectId
 from common import (
     api_client_int,
-    artifact_from_data,
+    artifact_rootfs_from_data,
     mongo,
     clean_db,
     clean_minio,
@@ -67,7 +67,7 @@ class TestInternalApiTenantCreate:
         assert r.status_code == 201
 
         # generate artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=device_type
         ) as art:
             artifacts_client = SimpleArtifactsClient()
@@ -109,7 +109,7 @@ class TestInternalApiTenantCreate:
         tenant_id = str(ObjectId())
 
         # generate artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=device_type
         ) as art:
             artifacts_client = SimpleArtifactsClient()

--- a/tests/tests/test_deployment.py
+++ b/tests/tests/test_deployment.py
@@ -26,7 +26,7 @@ from client import (
     InventoryClient,
     SimpleDeviceClient,
 )
-from common import artifact_from_data, Device
+from common import artifact_rootfs_from_data, Device
 
 
 class TestDeployment:
@@ -102,7 +102,7 @@ class TestDeployment:
         data = b"foo_bar"
         artifact_name = "hammer-update-" + str(uuid4())
         # come up with an artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=dev.device_type
         ) as art:
             ac = SimpleArtifactsClient()
@@ -186,7 +186,7 @@ class TestDeployment:
         data = b"foo_bar"
         artifact_name = "hammer-update-" + str(uuid4())
         # come up with an artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=dev.device_type
         ) as art:
             ac = SimpleArtifactsClient()
@@ -237,7 +237,7 @@ class TestDeployment:
         data = b"foo_bar"
         artifact_name = "pagination-test-" + str(uuid4())
         # come up with an artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=device_type
         ) as art:
             ac = SimpleArtifactsClient()
@@ -295,7 +295,7 @@ class TestDeployment:
         data = b"foo_bar"
         artifact_name = "hammer-update-" + str(uuid4())
         # come up with an artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=dev.device_type
         ) as art:
             ac = SimpleArtifactsClient()
@@ -362,7 +362,7 @@ class TestDeployment:
         data = b"foo_bar"
         artifact_name = "hammer-update-" + str(uuid4())
         # come up with an artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=dev.device_type
         ) as art:
             ac = SimpleArtifactsClient()
@@ -405,7 +405,7 @@ class TestDeployment:
         data = b"foo_bar"
         artifact_name = "hammer-update-" + str(uuid4())
         # come up with an artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=dev.device_type
         ) as art:
             ac = SimpleArtifactsClient()
@@ -525,7 +525,7 @@ class TestDeployment:
         data = b"foo_bar"
         artifact_name = "hammer-update-" + str(uuid4())
         # come up with an artifact
-        with artifact_from_data(
+        with artifact_rootfs_from_data(
             name=artifact_name, data=data, devicetype=dev.device_type
         ) as art:
             ac = SimpleArtifactsClient()


### PR DESCRIPTION
Amends commit 4f879a551de08cf1d7896de521950aaafa81ad30

Modify ArtifactUpdateTypeInfo struct and corresponding API spec to
accept either nil or string for type.

Implemented acceptance tests to cover basic operations with bootstrap
Artifacts.

Ticket: MEN-2583
Changelog: ArtifactTypeInfo object returned in `/artifacts` or
`/deployments/releases` can now return `nil` as its type. This would be
the case for bootstrap Artifacts.