### PR TITLE
chore(config): Remove unused config and correct configfile docs

### DIFF
--- a/Dockerfile.acceptance-testing
+++ b/Dockerfile.acceptance-testing
@@ -13,7 +13,6 @@ COPY ./entrypoint.sh /usr/bin/
 COPY  --from=builder /go/src/github.com/mendersoftware/deployments/deployments /usr/bin/deployments
 COPY ./config.yaml /usr/bin/
 
-ENV DEPLOYMENTS_MENDER_GATEWAY http://mender-inventory:8080
 ENTRYPOINT ["/usr/bin/entrypoint.sh", "server", "--automigrate"]
 
 STOPSIGNAL SIGINT

--- a/config.yaml
+++ b/config.yaml
@@ -62,9 +62,8 @@ mongo-url: "mongodb://mongo-deployments:27017"
 
 # Inventory service address
 # Defaults to: http://mender-inventory:8080
-# Env key: DEPLOYMENTS_MENDER_GATEWAY
-
-mender-gateway: "http://mender-inventory:8080"
+# Env key: DEPLOYMENTS_INVENTORY_ADDR
+inventory_addr: "http://mender-inventory:8080"
 
 # Workflows service address
 # Defaults to: http://mender-workflows-servers:8080

--- a/config/config.go
+++ b/config/config.go
@@ -88,9 +88,6 @@ const (
 	SettingDbUsername = "mongo_username"
 	SettingDbPassword = "mongo_password"
 
-	SettingGateway        = "mender-gateway"
-	SettingGatewayDefault = "localhost:9080"
-
 	SettingWorkflows        = "mender-workflows"
 	SettingWorkflowsDefault = "http://mender-workflows-server:8080"
 
@@ -280,7 +277,6 @@ var (
 		{Key: SettingMongo, Value: SettingMongoDefault},
 		{Key: SettingDbSSL, Value: SettingDbSSLDefault},
 		{Key: SettingDbSSLSkipVerify, Value: SettingDbSSLSkipVerifyDefault},
-		{Key: SettingGateway, Value: SettingGatewayDefault},
 		{Key: SettingWorkflows, Value: SettingWorkflowsDefault},
 		{Key: SettingsAwsTagArtifact, Value: SettingsAwsTagArtifactDefault},
 		{Key: SettingInventoryAddr, Value: SettingInventoryAddrDefault},


### PR DESCRIPTION
The `mender-gateway` configuration option is unused and was set to the default value of inventory_addr.