### PR TITLE
feat: add special representation of artifact provides to artifact object

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //	Licensed under the Apache License, Version 2.0 (the "License");
 //	you may not use this file except in compliance with the License.
@@ -333,9 +333,9 @@ var (
 	// 1.2.13
 	IndexArtifactProvides = mongo.IndexModel{
 		Keys: bson.D{
-			{Key: model.StorageKeyImageProvidesKey,
+			{Key: model.StorageKeyImageProvidesIdxKey,
 				Value: 1},
-			{Key: model.StorageKeyImageProvidesValue,
+			{Key: model.StorageKeyImageProvidesIdxValue,
 				Value: 1},
 		},
 		Options: &mopts.IndexOptions{
@@ -378,6 +378,7 @@ const (
 	StorageKeyId = "_id"
 
 	StorageKeyImageProvides    = "meta_artifact.provides"
+	StorageKeyImageProvidesIdx = "meta_artifact.provides_idx"
 	StorageKeyImageDepends     = "meta_artifact.depends"
 	StorageKeyImageDependsIdx  = "meta_artifact.depends_idx"
 	StorageKeyImageSize        = "size"
@@ -511,8 +512,14 @@ func (db *DataStoreMongo) GetReleases(
 	}
 
 	pipe = append(pipe, bson.D{
-		// Remove (possibly expensive) sub-document from pipeline
-		{Key: "$project", Value: bson.M{StorageKeyImageDependsIdx: 0}},
+		// Remove (possibly expensive) sub-documents from pipeline
+		{
+			Key: "$project",
+			Value: bson.M{
+				StorageKeyImageDependsIdx:  0,
+				StorageKeyImageProvidesIdx: 0,
+			},
+		},
 	})
 
 	pipe = append(pipe, bson.D{
@@ -665,6 +672,9 @@ func (db *DataStoreMongo) Update(ctx context.Context,
 	database := db.client.Database(mstore.DbFromContext(ctx, DatabaseName))
 	collImg := database.Collection(CollectionImages)
 
+	// add special representation of artifact provides
+	image.ArtifactMeta.ProvidesIdx = model.ProvidesIdx(image.ArtifactMeta.Provides)
+
 	image.SetModified(time.Now())
 	if res, err := collImg.ReplaceOne(
 		ctx, bson.M{"_id": image.Id}, image,
@@ -796,6 +806,9 @@ func (db *DataStoreMongo) InsertImage(ctx context.Context, image *model.Image) e
 	database := db.client.Database(mstore.DbFromContext(ctx, DatabaseName))
 	collImg := database.Collection(CollectionImages)
 
+	// add special representation of artifact provides
+	image.ArtifactMeta.ProvidesIdx = model.ProvidesIdx(image.ArtifactMeta.Provides)
+
 	_, err := collImg.InsertOne(ctx, image)
 	if err != nil {
 		if except, ok := err.(mongo.WriteException); ok {
@@ -828,9 +841,15 @@ func (db *DataStoreMongo) FindImageByID(ctx context.Context,
 
 	database := db.client.Database(mstore.DbFromContext(ctx, DatabaseName))
 	collImg := database.Collection(CollectionImages)
+	projection := bson.M{
+		StorageKeyImageDependsIdx:  0,
+		StorageKeyImageProvidesIdx: 0,
+	}
+	findOptions := mopts.FindOne()
+	findOptions.SetProjection(projection)
 
 	var image model.Image
-	if err := collImg.FindOne(ctx, bson.M{"_id": id}).
+	if err := collImg.FindOne(ctx, bson.M{"_id": id}, findOptions).
 		Decode(&image); err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
@@ -971,7 +990,12 @@ func (db *DataStoreMongo) ListImages(
 
 	}
 
+	projection := bson.M{
+		StorageKeyImageDependsIdx:  0,
+		StorageKeyImageProvidesIdx: 0,
+	}
 	findOptions := &mopts.FindOptions{}
+	findOptions.SetProjection(projection)
 	if filt != nil && filt.Page > 0 && filt.PerPage > 0 {
 		findOptions.SetSkip(int64((filt.Page - 1) * filt.PerPage))
 		findOptions.SetLimit(int64(filt.PerPage))

--- a/store/mongo/migration_1_2_13_test.go
+++ b/store/mongo/migration_1_2_13_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -32,66 +32,71 @@ func TestMigration_1_2_13(t *testing.T) {
 		t.Skip("skipping TestMigration_1_2_13 in short mode.")
 	}
 
-	testCases := map[string]struct {
-		inputImage  *OldImage
-		outputImage *model.Image
-	}{
-		"ok": {
-			inputImage: &OldImage{
-				Id: "0cb87b3d-4f08-420b-b004-4347c07f70f6",
-				OldArtifactMeta: &OldArtifactMeta{
-					Provides: map[string]string{"rootfs-image.checksum": "bar"},
-				},
-			},
-			outputImage: &model.Image{
-				Id: "0cb87b3d-4f08-420b-b004-4347c07f70f6",
-				ArtifactMeta: &model.ArtifactMeta{
-					Provides: model.Provides{"rootfs-image.checksum": "bar"},
-				},
-			},
+	db.Wipe()
+	c := db.Client()
+
+	ctx := context.TODO()
+
+	//store := NewDataStoreMongoWithClient(c)
+	database := c.Database(mstore.DbFromContext(ctx, DatabaseName))
+	collImg := database.Collection(CollectionImages)
+
+	inputImage := &model.Image{
+		Id: "0cb87b3d-4f08-420b-b004-4347c07f70f6",
+		ArtifactMeta: &model.ArtifactMeta{
+			Name:                  "foo",
+			DeviceTypesCompatible: []string{"foo"},
+			Provides:              map[string]string{"rootfs-image.checksum": "bar"},
 		},
 	}
-
-	for name, tc := range testCases {
-		t.Logf("test case: %s", name)
-
-		db.Wipe()
-		c := db.Client()
-
-		ctx := context.TODO()
-
-		//store := NewDataStoreMongoWithClient(c)
-		database := c.Database(mstore.DbFromContext(ctx, DatabaseName))
-		collImg := database.Collection(CollectionImages)
-
-		// insert image
-		_, err := collImg.InsertOne(ctx, tc.inputImage)
-		assert.NoError(t, err)
-
-		query := bson.M{
-			model.StorageKeyImageProvidesKey:   "rootfs-image.checksum",
-			model.StorageKeyImageProvidesValue: "bar",
-		}
-		// get old image using new query
-		// there should be no documents in the result
-		oldImage := OldImage{}
-		err = collImg.FindOne(ctx, query).Decode(&oldImage)
-		assert.EqualError(t, err, mongo.ErrNoDocuments.Error())
-
-		// apply migration (1.2.13)
-		mnew := &migration_1_2_13{
-			client: c,
-			db:     DbName,
-		}
-		err = mnew.Up(migrate.MakeVersion(1, 2, 13))
-		assert.NoError(t, err)
-
-		// get new image using new query
-		// this time the image should be in the result
-		image := model.Image{}
-		err = collImg.FindOne(ctx, query).Decode(&image)
-		assert.NoError(t, err)
-		assert.Equal(t, *tc.outputImage, image)
+	outputImage := &model.Image{
+		Id: "0cb87b3d-4f08-420b-b004-4347c07f70f6",
+		ArtifactMeta: &model.ArtifactMeta{
+			Name:                  "foo",
+			DeviceTypesCompatible: []string{"foo"},
+			Provides:              map[string]string{"rootfs-image.checksum": "bar"},
+			ProvidesIdx:           model.ProvidesIdx{"rootfs-image.checksum": "bar"},
+			Depends:               map[string]interface{}{"device_type": bson.A{"foo"}},
+		},
 	}
+	// insert image
+	_, err := collImg.InsertOne(ctx, inputImage)
+	assert.NoError(t, err)
 
+	query := bson.M{
+		model.StorageKeyImageProvidesIdxKey:   "rootfs-image.checksum",
+		model.StorageKeyImageProvidesIdxValue: "bar",
+	}
+	// get old image using new query
+	// there should be no documents in the result
+	oldImage := model.Image{}
+	err = collImg.FindOne(ctx, query).Decode(&oldImage)
+	assert.EqualError(t, err, mongo.ErrNoDocuments.Error())
+
+	// apply migration (1.2.13)
+	mnew := &migration_1_2_13{
+		client: c,
+		db:     DbName,
+	}
+	err = mnew.Up(migrate.MakeVersion(1, 2, 13))
+	assert.NoError(t, err)
+
+	// get new image using new query
+	// this time the image should be in the result
+	image := model.Image{}
+	err = collImg.FindOne(ctx, query).Decode(&image)
+	assert.NoError(t, err)
+	assert.Equal(t, *outputImage, image)
+
+	// verify new index is in place
+	indexes := collImg.Indexes()
+	cursor, _ := indexes.List(ctx)
+	for cursor.Next(ctx) {
+		var tmp map[string]interface{}
+		_ = cursor.Decode(&tmp)
+		t.Log(tmp)
+	}
+	hasNew, err := hasIndex(ctx, IndexArtifactProvidesName, indexes)
+	assert.NoError(t, err)
+	assert.True(t, hasNew)
 }


### PR DESCRIPTION
This way we can index provides, but we don't have to wait for the migration to complete before we'll start using new index.
