### PR TITLE
feat: omit configuration values in the deployment details

### DIFF
--- a/model/configuration_deployment.go
+++ b/model/configuration_deployment.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -21,6 +21,11 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pkg/errors"
+)
+
+const (
+	omitted        = "...<omitted>"
+	lengthOmission = 3
 )
 
 // configuration saves the configuration as a binary blob
@@ -109,4 +114,24 @@ func NewDeploymentFromConfigurationDeploymentConstructor(
 	deployment.DeviceCount = &deviceCount
 
 	return deployment, nil
+}
+
+type deploymentConfiguration []byte
+
+func (c deploymentConfiguration) MarshalJSON() ([]byte, error) {
+	var configuration map[string]string
+	err := json.Unmarshal(c, &configuration)
+	if err != nil {
+		return json.Marshal(c)
+	}
+	for key, value := range configuration {
+		if len(value) > lengthOmission {
+			configuration[key] = value[0:lengthOmission] + omitted
+		}
+	}
+	data, err := json.Marshal(configuration)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(data)
 }

--- a/model/configuration_deployment_test.go
+++ b/model/configuration_deployment_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -15,14 +15,32 @@
 package model
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConfigurationDeploymentValidate(t *testing.T) {
+func TestDeploymentConfigurationMarshalJSON(t *testing.T) {
+	data := map[string]string{
+		"key":         "value",
+		"another-key": "another-value",
+	}
+	dataJSON, err := json.Marshal(data)
+	assert.NoError(t, err)
 
+	var c deploymentConfiguration
+	c = deploymentConfiguration(dataJSON)
+
+	dataJSON, err = json.Marshal(c)
+	assert.NoError(t, err)
+	expected := base64.StdEncoding.EncodeToString([]byte("{\"another-key\":\"ano...\\u003comitted\\u003e\",\"key\":\"val...\\u003comitted\\u003e\"}"))
+	assert.Equal(t, "\""+expected+"\"", string(dataJSON))
+}
+
+func TestConfigurationDeploymentValidate(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {

--- a/model/deployment.go
+++ b/model/deployment.go
@@ -165,7 +165,7 @@ type Deployment struct {
 	// artifact for the device.
 	// The artifact will be generated when the device will ask
 	// for an update.
-	Configuration []byte `json:"configuration,omitempty" bson:"configuration"`
+	Configuration deploymentConfiguration `json:"configuration,omitempty" bson:"configuration"`
 }
 
 // NewDeployment creates new deployment object, sets create data by default.


### PR DESCRIPTION
Configuration settings can contain sensitive values. Therefore, we mask the values to limit the reask of leaking secrets through the deployments APIs.

Changelog: Title
Ticket: None