### PR TITLE
chore: api docs check fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,6 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-acceptance.yml'
   - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-apidocs.yml'
-  - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
@@ -59,3 +57,25 @@ publish:acceptance:
 
 publish:unittests:
   image: golang:1.18-alpine3.16
+
+test:validate-open-api:
+  tags:
+    - mender-qa-worker-generic-light
+  stage: test
+  image:
+    name: alpine
+  before_script:
+    - apk --update add curl
+    - curl -L https://raw.github.com/stoplightio/spectral/master/scripts/install.sh -o install.sh
+    - sh install.sh
+  script:
+    - |
+      echo "extends: ['spectral:oas']" > .spectral.yaml
+    - spectral lint -v -D -f junit -o spectral-report.xml docs/*.yml
+  allow_failure: true
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    reports:
+      junit: $CI_PROJECT_DIR/spectral-report.xml
+


### PR DESCRIPTION
api docs lint checks were not running due to:

WARNING: Entrypoint override disabled

and using the override itself.

example of a job in master:

https://gitlab.com/Northern.tech/Mender/deployments/-/jobs/4214764960

the problem with this fix: spectral lint returns 1 shall I add || true and if so, how to detect the failure?

Ticket: None