### PR TITLE
MEN-6501: Add s3 configuration for unsigned headers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -179,8 +179,15 @@ aws:
     # Enable the S3 Transfer Acceleration for the operations that support it.
     # Defaults to: false
     # Overwrite with environment variable: DEPLOYMENTS_AWS_USE_ACCELERATE
-
+    #
     # use_accelerate: false
+
+    # Unsigned Headers excluded from AWS Signature v4 if present.
+    # Defaults to "Accept-Encoding" to remain compatible with GCS.
+    # Also accepts space separated list of header keys.
+    # Overwrite with environment variable: DEPLOYMENTS_AWS_UNSIGNED_HEADERS
+    #
+    # unsigned_headers: ["Accept-Encoding"]
 
     # S3 URI (for mender-deployment)
     # Defaults to: none (s3.amazonaws.com)

--- a/config/config.go
+++ b/config/config.go
@@ -66,8 +66,11 @@ const (
 	SettingAwsS3UseAccelerateDefault  = false
 	SettingAwsURI                     = SettingsAws + ".uri"
 	SettingAwsExternalURI             = SettingsAws + ".external_uri"
-	SettingsAwsTagArtifact            = SettingsAws + ".tag_artifact"
-	SettingsAwsTagArtifactDefault     = false
+	SettingAwsUnsignedHeaders         = SettingsAws + ".unsigned_headers"
+	SettingAwsUnsignedHeadersDefault  = "Accept-Encoding"
+
+	SettingsAwsTagArtifact        = SettingsAws + ".tag_artifact"
+	SettingsAwsTagArtifactDefault = false
 
 	SettingsAwsAuth      = SettingsAws + ".auth"
 	SettingAwsAuthKeyId  = SettingsAwsAuth + ".key"
@@ -279,6 +282,7 @@ var (
 		{Key: SettingStorageEnableDirectUpload, Value: SettingStorageEnableDirectUploadDefault},
 		{Key: SettingAwsS3ForcePathStyle, Value: SettingAwsS3ForcePathStyleDefault},
 		{Key: SettingAwsS3UseAccelerate, Value: SettingAwsS3UseAccelerateDefault},
+		{Key: SettingAwsUnsignedHeaders, Value: SettingAwsUnsignedHeadersDefault},
 		{Key: SettingStorageMaxImageSize, Value: SettingStorageMaxImageSizeDefault},
 		{Key: SettingsStorageDownloadExpireSeconds,
 			Value: SettingsStorageDownloadExpireSecondsDefault},

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.6
 	github.com/aws/aws-sdk-go-v2/config v1.18.18
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.6
+	github.com/aws/smithy-go v1.13.5
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/google/uuid v1.3.0
 	github.com/mendersoftware/go-lib-micro v0.0.0-20221025103319-e1f941fb3145
@@ -37,7 +38,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.6 // indirect
-	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect

--- a/server.go
+++ b/server.go
@@ -67,6 +67,9 @@ func SetupS3(ctx context.Context, defaultOptions *s3.Options) (storage.ObjectSto
 	if c.IsSet(dconfig.SettingAwsExternalURI) {
 		options.SetExternalURI(c.GetString(dconfig.SettingAwsExternalURI))
 	}
+	if c.IsSet(dconfig.SettingAwsUnsignedHeaders) {
+		options.SetUnsignedHeaders(c.GetStringSlice(dconfig.SettingAwsUnsignedHeaders))
+	}
 
 	storage, err := s3.New(ctx, bucket, options)
 	return storage, err

--- a/storage/s3/options.go
+++ b/storage/s3/options.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -181,7 +181,7 @@ func (opts *Options) toS3Options() (
 			endpointURI := *opts.URI
 			s3Opts.EndpointResolver = s3.EndpointResolverFromURL(endpointURI,
 				func(ep *aws.Endpoint) {
-					ep.HostnameImmutable = true
+					ep.HostnameImmutable = opts.ForcePathStyle
 				},
 			)
 		}

--- a/storage/s3/s3_test.go
+++ b/storage/s3/s3_test.go
@@ -16,12 +16,17 @@ package s3
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -34,7 +39,6 @@ func TestHealthCheck(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			return
 		},
 	))
 	defer srv.Close()
@@ -69,43 +73,217 @@ func TestHealthCheck(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func newTestServerAndClient(handler http.Handler) (*SimpleStorageService, *httptest.Server) {
-	srv := httptest.NewServer(handler)
-	var d net.Dialer
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return d.DialContext(
-					ctx,
-					srv.Listener.Addr().Network(),
-					srv.Listener.Addr().String(),
-				)
-			},
-			DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return d.DialContext(
-					ctx,
-					srv.Listener.Addr().Network(),
-					srv.Listener.Addr().String(),
-				)
-			},
-		},
-	}
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
 
-	s3c := s3.New(s3.Options{
-		Region:     "region",
-		HTTPClient: httpClient,
-		Credentials: StaticCredentials{
-			Key:    "test",
-			Secret: "secret",
-			Token:  "token",
-		},
+func (r RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return r(req)
+}
+
+func TestNewClient(t *testing.T) {
+	// Test initializing a new client and that the pre-conditions are checked:
+	// HeadBucket(404) -> CreateBucket(200) -> HeadBucket(404)
+	const (
+		bucketName     = "artifacts"
+		hostName       = "testing.mender.io"
+		bucketHostname = bucketName + "." + hostName
+		region         = "poddlest"
+		keyID          = "awskeyID"
+		secret         = "secretkey"
+		token          = "tokenMcTokenFace"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+	done := ctx.Done()
+
+	chReq := make(chan *http.Request, 1)
+	chRsp := make(chan *http.Response, 1)
+	rt := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		done := req.Context().Done()
+		b, _ := httputil.DumpRequest(req, false)
+		t.Log(string(b))
+		assert.Equal(t, bucketHostname, req.URL.Host)
+
+		// Check X-Amz-Date header
+		amzTimeStr := req.Header.Get(paramAmzDate)
+		amzTime, err := time.Parse(paramAmzDateFormat, amzTimeStr)
+		if assert.NoError(t, err, "unexpected X-Amz-Date header value") {
+			assert.WithinDuration(t, time.Now(), amzTime, time.Minute)
+		}
+
+		// Check X-Amz-Security-Token
+		assert.Equal(t, token, req.Header.Get("X-Amz-Security-Token"))
+
+		authz := req.Header.Get("Authorization")
+		if assert.NotEmpty(t, authz) {
+			assert.True(t,
+				strings.HasPrefix(authz, "AWS4-HMAC-SHA256"),
+				"unexpected Authorization header type")
+			authz = strings.TrimPrefix(authz, "AWS4-HMAC-SHA256")
+			idxDate := strings.IndexRune(amzTimeStr, 'T')
+			if idxDate < 0 {
+				idxDate = len(amzTimeStr)
+			}
+			expectedParams := map[string]struct{}{
+				"Credential":    struct{}{},
+				"Signature":     struct{}{},
+				"SignedHeaders": struct{}{},
+			}
+			for _, param := range strings.Fields(authz) {
+				keyValue := strings.SplitN(param, "=", 2)
+				if len(keyValue) != 2 {
+					continue
+				}
+				key, value := keyValue[0], keyValue[1]
+				value = strings.TrimRight(value, ",")
+				switch key {
+				case "Credential":
+					assert.Equal(t, fmt.Sprintf("%s/%s/%s/s3/aws4_request",
+						keyID,
+						amzTimeStr[:idxDate],
+						region,
+					), value, "Invalid Authorization parameter Credential")
+				case "Signature":
+
+				case "SignedHeaders":
+					for _, hdr := range []string{"host", "x-amz-date", "x-amz-security-token"} {
+						assert.Containsf(t,
+							value,
+							hdr,
+							"SignedHeaders does not contain header %q",
+							hdr)
+					}
+				default:
+					continue
+				}
+				delete(expectedParams, key)
+			}
+			assert.Empty(t, expectedParams,
+				"Some expected Authorization parameters was not present")
+		}
+
+		select {
+		case chReq <- req:
+		case <-done:
+			return nil, errors.New("timeout")
+		}
+
+		var rsp *http.Response
+		select {
+		case rsp = <-chRsp:
+		case <-done:
+			return nil, errors.New("timeout")
+		}
+
+		if rsp == nil {
+			err = errors.New("nil Response")
+		}
+
+		return rsp, err
 	})
 
-	sss := &SimpleStorageService{
-		client:        s3c,
-		presignClient: s3.NewPresignClient(s3c),
-		bucket:        "bucket",
+	options := NewOptions().
+		SetBufferSize(5*1024*1024).
+		SetContentType("test").
+		SetDefaultExpire(time.Minute).
+		SetRegion(region).
+		SetStaticCredentials(keyID, secret, token).
+		SetURI("https://" + hostName).
+		SetForcePathStyle(false).
+		SetUseAccelerate(true).
+		SetUnsignedHeaders([]string{"Accept-Encoding"}).
+		SetTransport(rt)
+
+	go func() {
+		_, err := New(ctx, bucketName, options) //nolint:errcheck
+		assert.NoError(t, err)
+		cancel()
+	}()
+
+	// HeadBucket
+	select {
+	case req := <-chReq:
+		assert.Equal(t, http.MethodHead, req.Method)
+		w := httptest.NewRecorder()
+		w.WriteHeader(http.StatusNotFound)
+		chRsp <- w.Result()
+
+	case <-done:
+		assert.FailNow(t, "timeout waiting for request")
 	}
+
+	// PutBucket
+	select {
+	case req := <-chReq:
+		assert.Equal(t, http.MethodPut, req.Method)
+		w := httptest.NewRecorder()
+		w.WriteHeader(http.StatusOK)
+		chRsp <- w.Result()
+
+	case <-done:
+		assert.FailNow(t, "timeout waiting for request")
+	}
+
+	// HeadBucket
+	select {
+	case req := <-chReq:
+		assert.Equal(t, http.MethodHead, req.Method)
+		w := httptest.NewRecorder()
+		w.WriteHeader(http.StatusOK)
+		chRsp <- w.Result()
+
+	case <-done:
+		assert.FailNow(t, "timeout waiting for request")
+	}
+
+}
+
+func newTestServerAndClient(
+	handler http.Handler,
+	opts ...*Options,
+) (storage.ObjectStorage, *httptest.Server) {
+	initHandler := http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodHead, http.MethodPut:
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		},
+	)
+	srv := httptest.NewServer(initHandler)
+	var d net.Dialer
+	httpTransport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return d.DialContext(
+				ctx,
+				srv.Listener.Addr().Network(),
+				srv.Listener.Addr().String(),
+			)
+		},
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return d.DialContext(
+				ctx,
+				srv.Listener.Addr().Network(),
+				srv.Listener.Addr().String(),
+			)
+		},
+	}
+
+	opt := NewOptions().
+		SetRegion("region").
+		SetStaticCredentials("test", "secret", "token")
+	opts = append([]*Options{opt}, opts...)
+
+	opt = NewOptions(opts...).
+		SetTransport(httpTransport)
+
+	sss, err := New(context.Background(), "bucket", opt)
+	if err != nil {
+		panic(err)
+	}
+	srv.Config.Handler = handler
 	return sss, srv
 }
 


### PR DESCRIPTION
The new configuration `aws.unsigned_headers` defaults to `Accept-Encoding` to restore support for Google Cloud Storage s3 API.