### PR TITLE
test: Fix race condition in TestGetReleases_1_2_15

### DIFF
--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -418,6 +418,7 @@ func TestGetReleases_1_2_15(t *testing.T) {
 		for i, devType := range img.ArtifactMeta.DeviceTypesCompatible {
 			img.ArtifactMeta.Depends["device_type"].(bson.A)[i] = devType
 		}
+		time.Sleep(time.Millisecond * 10)
 	}
 
 	testCases := map[string]struct {


### PR DESCRIPTION
Since two consecutive inserts in MongoDB easily takes less than 1ms the `modified` timestamp may turn out to be the same in many cases (hence the spurious errors).