### PR TITLE
MEN-6348: Introduce release tags and endpoints for listing keys

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -1953,7 +1953,6 @@ func (d *DeploymentsApiHandlers) PutReleaseTags(
 	w rest.ResponseWriter,
 	r *rest.Request,
 ) {
-	defer r.Body.Close()
 	ctx := r.Context()
 	l := log.FromContext(ctx)
 
@@ -1994,4 +1993,31 @@ func (d *DeploymentsApiHandlers) PutReleaseTags(
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (d *DeploymentsApiHandlers) GetReleaseTagKeys(
+	w rest.ResponseWriter,
+	r *rest.Request,
+) {
+	ctx := r.Context()
+	l := log.FromContext(ctx)
+
+	releaseName := r.PathParam(ParamName)
+	if releaseName == "" {
+		err := errors.New("path parameter 'release_name' cannot be empty")
+		rest_utils.RestErrWithLog(w, r, l, err, http.StatusNotFound)
+		return
+	}
+
+	tags, err := d.app.ListReleaseTags(ctx)
+	if err != nil {
+		rest_utils.RestErrWithLog(w, r, l, err, http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	err = w.WriteJson(tags)
+	if err != nil {
+		l.Errorf("failed to serialize JSON response: %s", err.Error())
+	}
 }

--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -1942,6 +1943,53 @@ func (d *DeploymentsApiHandlers) PutTenantStorageSettingsHandler(
 	err = d.app.SetStorageSettings(ctx, settings)
 	if err != nil {
 		rest_utils.RestErrWithLogInternal(w, r, l, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (d *DeploymentsApiHandlers) PutReleaseTags(
+	w rest.ResponseWriter,
+	r *rest.Request,
+) {
+	defer r.Body.Close()
+	ctx := r.Context()
+	l := log.FromContext(ctx)
+
+	releaseName := r.PathParam(ParamName)
+	if releaseName == "" {
+		err := errors.New("path parameter 'release_name' cannot be empty")
+		rest_utils.RestErrWithLog(w, r, l, err, http.StatusNotFound)
+		return
+	}
+
+	var tags model.Tags
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&tags); err != nil {
+		rest_utils.RestErrWithLog(w, r, l,
+			errors.WithMessage(err,
+				"malformed JSON in request body"),
+			http.StatusBadRequest)
+		return
+	}
+	if err := tags.Validate(); err != nil {
+		rest_utils.RestErrWithLog(w, r, l,
+			errors.WithMessage(err,
+				"invalid request body"),
+			http.StatusBadRequest)
+		return
+	}
+
+	err := d.app.ReplaceReleaseTags(ctx, releaseName, tags)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, app.ErrReleaseNotFound) {
+			status = http.StatusNotFound
+		} else if errors.Is(err, model.ErrTooManyUniqueTags) {
+			status = http.StatusConflict
+		}
+		rest_utils.RestErrWithLog(w, r, l, err, status)
 		return
 	}
 

--- a/api/http/api_deployments_test.go
+++ b/api/http/api_deployments_test.go
@@ -2857,3 +2857,140 @@ func TestPutReleaseTags(t *testing.T) {
 		})
 	}
 }
+
+func TestListReleaseTags(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		Name string
+
+		App func(t *testing.T, self *testCase) *mapp.App
+		*http.Request
+
+		StatusCode int
+		Tags       []string
+	}
+
+	testCases := []testCase{{
+		Name: "ok",
+
+		Request: func() *http.Request {
+			req, _ := http.NewRequest(
+				http.MethodGet,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTagKeys,
+						"#name", "release-mc-release-face"),
+				),
+				nil,
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			appie := new(mapp.App)
+			appie.On("ListReleaseTags",
+				contextMatcher()).
+				Return(self.Tags, nil)
+			return appie
+		},
+
+		StatusCode: http.StatusOK,
+		Tags:       []string{"foo", "bar", "baz"},
+	}, {
+		Name: "error/internal",
+
+		Request: func() *http.Request {
+			req, _ := http.NewRequest(
+				http.MethodGet,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTagKeys,
+						"#name", "release-mc-release-face"),
+				),
+				nil,
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			appie := new(mapp.App)
+			appie.On("ListReleaseTags",
+				contextMatcher()).
+				Return(nil, errors.New("internal error"))
+			return appie
+		},
+
+		StatusCode: http.StatusInternalServerError,
+	}, {
+		Name: "error/internal",
+
+		Request: func() *http.Request {
+			req, _ := http.NewRequest(
+				http.MethodGet,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTagKeys,
+						"#name", "release-mc-release-face"),
+				),
+				nil,
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			appie := new(mapp.App)
+			appie.On("ListReleaseTags",
+				contextMatcher()).
+				Return(nil, errors.New("internal error"))
+			return appie
+		},
+
+		StatusCode: http.StatusInternalServerError,
+	}, {
+		Name: "error/release name empty",
+
+		Request: func() *http.Request {
+			req, _ := http.NewRequest(
+				http.MethodGet,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTagKeys,
+						"#name", ""),
+				),
+				nil,
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			return new(mapp.App)
+		},
+
+		StatusCode: http.StatusNotFound,
+	}}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			appie := tc.App(t, &tc)
+			defer appie.AssertExpectations(t)
+
+			handlers := NewDeploymentsApiHandlers(nil, &view.RESTView{}, appie)
+			routes := ReleasesRoutes(handlers)
+			router, _ := rest.MakeRouter(routes...)
+			api := rest.NewApi()
+			api.SetApp(router)
+			handler := api.MakeHandler()
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, tc.Request)
+
+			rsp := w.Result()
+			assert.Equal(t, tc.StatusCode, rsp.StatusCode,
+				"unexpected status code from request")
+			if tc.Tags != nil {
+				var actual []string
+				err := json.Unmarshal(w.Body.Bytes(), &actual)
+				if assert.NoError(t, err, "unexpected request body") {
+					assert.Equal(t, tc.Tags, actual)
+				}
+			}
+		})
+	}
+}

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -62,8 +62,9 @@ const (
 
 	ApiUrlManagementLimitsName = ApiUrlManagement + "/limits/#name"
 
-	ApiUrlManagementV2            = "/api/management/v2/deployments"
-	ApiUrlManagementV2ReleaseTags = ApiUrlManagementV2 + "/releases/#name/tags"
+	ApiUrlManagementV2               = "/api/management/v2/deployments"
+	ApiUrlManagementV2ReleaseTags    = ApiUrlManagementV2 + "/releases/#name/tags"
+	ApiUrlManagementV2ReleaseTagKeys = ApiUrlManagementV2 + "/releases/#name/tags/keys"
 
 	ApiUrlDevicesDeploymentsNext  = ApiUrlDevices + "/device/deployments/next"
 	ApiUrlDevicesDeploymentStatus = ApiUrlDevices + "/device/deployments/#id/status"
@@ -256,6 +257,7 @@ func ReleasesRoutes(controller *DeploymentsApiHandlers) []*rest.Route {
 		rest.Get(ApiUrlManagementReleases, controller.GetReleases),
 		rest.Get(ApiUrlManagementReleasesList, controller.ListReleases),
 		rest.Put(ApiUrlManagementV2ReleaseTags, controller.PutReleaseTags),
+		rest.Get(ApiUrlManagementV2ReleaseTagKeys, controller.GetReleaseTagKeys),
 	}
 }
 

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -62,6 +62,9 @@ const (
 
 	ApiUrlManagementLimitsName = ApiUrlManagement + "/limits/#name"
 
+	ApiUrlManagementV2            = "/api/management/v2/deployments"
+	ApiUrlManagementV2ReleaseTags = ApiUrlManagementV2 + "/releases/#name/tags"
+
 	ApiUrlDevicesDeploymentsNext  = ApiUrlDevices + "/device/deployments/next"
 	ApiUrlDevicesDeploymentStatus = ApiUrlDevices + "/device/deployments/#id/status"
 	ApiUrlDevicesDeploymentsLog   = ApiUrlDevices + "/device/deployments/#id/log"
@@ -252,6 +255,7 @@ func ReleasesRoutes(controller *DeploymentsApiHandlers) []*rest.Route {
 	return []*rest.Route{
 		rest.Get(ApiUrlManagementReleases, controller.GetReleases),
 		rest.Get(ApiUrlManagementReleasesList, controller.ListReleases),
+		rest.Put(ApiUrlManagementV2ReleaseTags, controller.PutReleaseTags),
 	}
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -192,6 +192,7 @@ type App interface {
 
 	// releases
 	ReplaceReleaseTags(ctx context.Context, releaseName string, tags model.Tags) error
+	ListReleaseTags(ctx context.Context) ([]string, error)
 }
 
 type Deployments struct {
@@ -2115,6 +2116,16 @@ func (d *Deployments) updateRelease(
 	}
 
 	return d.db.UpdateReleaseArtifacts(ctx, artifactToAdd, artifactToRemove, name)
+}
+
+func (d *Deployments) ListReleaseTags(ctx context.Context) ([]string, error) {
+	tags, err := d.db.ListReleaseTagKeys(ctx)
+	if err != nil {
+		log.FromContext(ctx).
+			Errorf("failed to list release tags: %s", err)
+		err = ErrModelInternal
+	}
+	return tags, err
 }
 
 func (d *Deployments) ReplaceReleaseTags(

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1847,3 +1847,62 @@ func TestReplaceReleaseTags(t *testing.T) {
 		})
 	}
 }
+
+func TestListReleaseTags(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		Name string
+
+		context.Context
+
+		GetDatabase func(t *testing.T, self *testCase) *mocks.DataStore
+
+		Tags  []string
+		Error error
+	}
+	testCases := []testCase{{
+		Name: "ok",
+
+		Context: context.Background(),
+		Tags:    []string{"field1", "field2"},
+
+		GetDatabase: func(t *testing.T, self *testCase) *mocks.DataStore {
+			ds := new(mocks.DataStore)
+			ds.On("ListReleaseTagKeys", self.Context).
+				Return(self.Tags, nil)
+			return ds
+		},
+	}, {
+		Name: "error/internal error",
+
+		Context: context.Background(),
+
+		GetDatabase: func(t *testing.T, self *testCase) *mocks.DataStore {
+			ds := new(mocks.DataStore)
+			ds.On("ListReleaseTagKeys", self.Context).
+				Return(nil, errors.New("internal error with sensitive info"))
+			return ds
+		},
+		Error: ErrModelInternal,
+	}}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ds := tc.GetDatabase(t, &tc)
+			defer ds.AssertExpectations(t)
+
+			app := NewDeployments(ds, nil)
+
+			tags, err := app.ListReleaseTags(tc.Context)
+			if tc.Error != nil {
+				assert.ErrorIs(t, err, tc.Error)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.Tags, tags)
+			}
+		})
+	}
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1757,3 +1757,93 @@ func TestReindexDeployment(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceReleaseTags(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		Name string
+
+		context.Context
+		ReleaseName string
+		Tags        model.Tags
+
+		GetDatabase func(t *testing.T, self *testCase) *mocks.DataStore
+
+		Error error
+	}
+	testCases := []testCase{{
+		Name: "ok",
+
+		Context:     context.Background(),
+		ReleaseName: "foobar",
+		Tags:        model.Tags{{Key: "foo", Value: "baz"}},
+
+		GetDatabase: func(t *testing.T, self *testCase) *mocks.DataStore {
+			ds := new(mocks.DataStore)
+			ds.On("ReplaceReleaseTags", self.Context, self.ReleaseName, self.Tags).
+				Return(nil)
+			return ds
+		},
+	}, {
+		Name: "error/not found",
+
+		Context:     context.Background(),
+		ReleaseName: "foobar",
+		Tags:        model.Tags{{Key: "foo", Value: "baz"}},
+
+		GetDatabase: func(t *testing.T, self *testCase) *mocks.DataStore {
+			ds := new(mocks.DataStore)
+			ds.On("ReplaceReleaseTags", self.Context, self.ReleaseName, self.Tags).
+				Return(store.ErrNotFound)
+			return ds
+		},
+		Error: ErrReleaseNotFound,
+	}, {
+		Name: "error/too many unique keys",
+
+		Context:     context.Background(),
+		ReleaseName: "foobar",
+		Tags:        model.Tags{{Key: "foo", Value: "baz"}},
+
+		GetDatabase: func(t *testing.T, self *testCase) *mocks.DataStore {
+			ds := new(mocks.DataStore)
+			ds.On("ReplaceReleaseTags", self.Context, self.ReleaseName, self.Tags).
+				Return(model.ErrTooManyUniqueTags)
+			return ds
+		},
+		Error: model.ErrTooManyUniqueTags,
+	}, {
+		Name: "error/internal error",
+
+		Context:     context.Background(),
+		ReleaseName: "foobar",
+		Tags:        model.Tags{{Key: "foo", Value: "baz"}},
+
+		GetDatabase: func(t *testing.T, self *testCase) *mocks.DataStore {
+			ds := new(mocks.DataStore)
+			ds.On("ReplaceReleaseTags", self.Context, self.ReleaseName, self.Tags).
+				Return(errors.New("internal error with sensitive info"))
+			return ds
+		},
+		Error: ErrModelInternal,
+	}}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ds := tc.GetDatabase(t, &tc)
+			defer ds.AssertExpectations(t)
+
+			app := NewDeployments(ds, nil)
+
+			err := app.ReplaceReleaseTags(tc.Context, tc.ReleaseName, tc.Tags)
+			if tc.Error != nil {
+				assert.ErrorIs(t, err, tc.Error)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -650,6 +650,29 @@ func (_m *App) ListImages(ctx context.Context, filters *model.ReleaseOrImageFilt
 	return r0, r1, r2
 }
 
+// ListReleaseTags provides a mock function with given fields: ctx
+func (_m *App) ListReleaseTags(ctx context.Context) ([]string, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LookupDeployment provides a mock function with given fields: ctx, query
 func (_m *App) LookupDeployment(ctx context.Context, query model.Query) ([]*model.Deployment, int64, error) {
 	ret := _m.Called(ctx, query)

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -269,27 +269,6 @@ func (_m *App) GenerateImage(ctx context.Context, multipartUploadMsg *model.Mult
 	return r0, r1
 }
 
-// GetDeviceDeploymentLastStatus provides a mock function with given fields: ctx, devicesIds
-func (_m *App) GetDeviceDeploymentLastStatus(ctx context.Context, devicesIds []string) (model.DeviceDeploymentLastStatuses, error) {
-	ret := _m.Called(ctx, devicesIds)
-
-	var r0 model.DeviceDeploymentLastStatuses
-	if rf, ok := ret.Get(0).(func(context.Context, []string) model.DeviceDeploymentLastStatuses); ok {
-		r0 = rf(ctx, devicesIds)
-	} else {
-		r0 = ret.Get(0).(model.DeviceDeploymentLastStatuses)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
-		r1 = rf(ctx, devicesIds)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetDeployment provides a mock function with given fields: ctx, deploymentID
 func (_m *App) GetDeployment(ctx context.Context, deploymentID string) (*model.Deployment, error) {
 	ret := _m.Called(ctx, deploymentID)
@@ -382,6 +361,27 @@ func (_m *App) GetDeploymentsStats(ctx context.Context, deploymentIDs ...string)
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, ...string) error); ok {
 		r1 = rf(ctx, deploymentIDs...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetDeviceDeploymentLastStatus provides a mock function with given fields: ctx, devicesIds
+func (_m *App) GetDeviceDeploymentLastStatus(ctx context.Context, devicesIds []string) (model.DeviceDeploymentLastStatuses, error) {
+	ret := _m.Called(ctx, devicesIds)
+
+	var r0 model.DeviceDeploymentLastStatuses
+	if rf, ok := ret.Get(0).(func(context.Context, []string) model.DeviceDeploymentLastStatuses); ok {
+		r0 = rf(ctx, devicesIds)
+	} else {
+		r0 = ret.Get(0).(model.DeviceDeploymentLastStatuses)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = rf(ctx, devicesIds)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -687,6 +687,20 @@ func (_m *App) ProvisionTenant(ctx context.Context, tenant_id string) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, tenant_id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ReplaceReleaseTags provides a mock function with given fields: ctx, releaseName, tags
+func (_m *App) ReplaceReleaseTags(ctx context.Context, releaseName string, tags model.Tags) error {
+	ret := _m.Called(ctx, releaseName, tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.Tags) error); ok {
+		r0 = rf(ctx, releaseName, tags)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -2184,6 +2184,19 @@ definitions:
         description: List of artifacts for this release.
         items:
           $ref: "#/definitions/Artifact"
+      tags:
+        type: array
+        description: |-
+          Tags assigned to the release used for filtering releases.
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The name of the tag.
+            value:
+              type: string
+              description: The value of the tag.
     example:
       name: my-app-v1.0.1
       artifacts:

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -46,7 +46,7 @@ responses:
 paths:
   /deployments/releases/{release_name}/tags:
     put:
-      operationId: Replace release tags
+      operationId: Assign Release Tags
       tags:
         - Management API
       security:
@@ -54,8 +54,12 @@ paths:
       summary: |
         Update and replace the tags of a release.
       description: |
-        Returns a collection of releases, allows filtering by release name and sorting
-        by name or last modification date.
+        Assigns tags to releases. The tags will be replaced with the ones
+        defined in the request body.
+
+        LIMITATIONS:
+          * Max 20 tags can be assigned to a single release.
+          * There can be no more than 100 unique tag keys in total.
       parameters:
         - name: release_name
           in: path

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -1,0 +1,117 @@
+swagger: '2.0'
+info:
+  title: Deployments v2
+  version: '2'
+  description: |
+    Version 2 of the API for deployments management.
+    Intended for use by the web GUI.
+
+host: 'hosted.mender.io'
+basePath: '/api/management/v2/deployments'
+schemes:
+  - https
+
+consumes:
+  - application/json
+produces:
+  - application/json
+
+securityDefinitions:
+  ManagementJWT:
+    type: apiKey
+    in: header
+    name: Authorization
+    description: |
+      API token issued by User Authentication service.
+      Format: 'Bearer [JWT]'
+
+responses:
+  InvalidRequestError: # 400
+    description: Bad request, see error message for details.
+    schema:
+      $ref: "#/definitions/Error"
+  UnauthorizedError: # 401
+    description: Unauthorized.
+    schema:
+      $ref: "#/definitions/Error"
+  UnprocessableEntityError: # 422
+    description: Unprocessable Entity.
+    schema:
+      $ref: "#/definitions/Error"
+  InternalServerError: # 500
+    description: Internal Server Error.
+    schema:
+      $ref: "#/definitions/Error"
+
+paths:
+  /deployments/releases/{release_name}/tags:
+    put:
+      operationId: Replace release tags
+      tags:
+        - Management API
+      security:
+        - ManagementJWT: []
+      summary: |
+        Update and replace the tags of a release.
+      description: |
+        Returns a collection of releases, allows filtering by release name and sorting
+        by name or last modification date.
+      parameters:
+        - name: release_name
+          in: path
+          description: Name of the release
+          required: true
+          type: string
+        - name: tags
+          in: body
+          schema:
+            $ref: "#/definitions/Tags"
+      produces:
+        - application/json
+      responses:
+        204:
+          description: Successful response.
+        400:
+          $ref: "#/responses/InvalidRequestError"
+        401:
+          $ref: "#/responses/UnauthorizedError"
+        409:
+          description: Too many unique tag keys in use.
+          schema:
+            $ref: "#/definitions/Error"
+
+          examples:
+            application/json:
+              error: "the total number of unique tags has been exceeded"
+              request_id: "f7881e82-0492-49fb-b459-795654e7188a"
+        500:
+          $ref: "#/responses/InternalServerError"
+
+
+definitions:
+  Tags:
+    description: Key/value pairs for filtering resources.
+    type: array
+    items:
+      type: object
+      properties:
+        key:
+          type: string
+          description: The name of the tag.
+        value:
+          type: string
+          description: The tag value.
+
+  Error:
+    description: Error descriptor.
+    type: object
+    properties:
+      error:
+        description: Description of the error.
+        type: string
+      request_id:
+        description: Request ID (same as in X-MEN-RequestID header).
+        type: string
+    example:
+      error: "failed to decode device group data: JSON payload is empty"
+      request_id: "f7881e82-0492-49fb-b459-795654e7188a"

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -91,6 +91,47 @@ paths:
         500:
           $ref: "#/responses/InternalServerError"
 
+  /deployments/releases/{release_name}/tags/keys:
+    get:
+      operationId: List Tags
+      tags:
+        - Management API
+      security:
+        - ManagementJWT: []
+      summary: |
+        Lists all available tags for releases.
+      parameters:
+        - name: release_name
+          in: path
+          description: Name of the release
+          required: true
+          type: string
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Successful response.
+          schema:
+            type: array
+            description: Release tag keys.
+            items:
+              type: string
+        400:
+          $ref: "#/responses/InvalidRequestError"
+        401:
+          $ref: "#/responses/UnauthorizedError"
+        409:
+          description: Too many unique tag keys in use.
+          schema:
+            $ref: "#/definitions/Error"
+
+          examples:
+            application/json:
+              error: "the total number of unique tags has been exceeded"
+              request_id: "f7881e82-0492-49fb-b459-795654e7188a"
+        500:
+          $ref: "#/responses/InternalServerError"
+
 
 definitions:
   Tags:

--- a/model/release.go
+++ b/model/release.go
@@ -11,14 +11,97 @@
 //	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //	See the License for the specific language governing permissions and
 //	limitations under the License.
+
 package model
 
-import "time"
+import (
+	"encoding/json"
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+const (
+	TagsPerReleaseMax = 20  // Maximum number of tags per release.
+	TagsMaxUniqueKeys = 100 // Maximum number of unique tag keys.
+)
+
+var (
+	ErrTooManyTags = errors.New(
+		"the total number of tags per exceeded maximum of " +
+			strconv.Itoa(TagsPerReleaseMax),
+	)
+	ErrTooManyUniqueTags = errors.New(
+		"the total number of unique tags (" +
+			strconv.Itoa(TagsMaxUniqueKeys) +
+			") has been exceeded",
+	)
+)
+
+type Tags []Tag
+
+func (tags Tags) Validate() (err error) {
+	if len(tags) > TagsPerReleaseMax {
+		return ErrTooManyTags
+	}
+	return validation.Validate([]Tag(tags))
+}
+
+func (tags Tags) MarshalJSON() ([]byte, error) {
+	if len(tags) == 0 {
+		return []byte{'[', ']'}, nil
+	}
+	return json.Marshal([]Tag(tags))
+}
+
+func (tags *Tags) UnmarshalJSON(b []byte) error {
+	err := json.Unmarshal(b, (*[]Tag)(tags))
+	if err != nil {
+		return err
+	}
+	// Deduplicate tag keys:
+	s := *tags
+	sort.SliceStable(s, func(i, j int) bool {
+		return strings.Compare(s[i].Key, s[j].Key) < 0
+	})
+	i := 1
+	for i < len(s) {
+		p := s[i]
+		if p.Key == s[i-1].Key {
+			// Swap duplicate and shrink slice
+			lastIdx := len(s) - 1
+			s[i] = s[lastIdx]
+			s[lastIdx] = p
+			s = s[:lastIdx]
+		} else {
+			i++
+		}
+	}
+	*tags = s
+	return nil
+}
+
+type Tag struct {
+	Key   string `json:"key" bson:"key"`
+	Value string `json:"value" bson:"value"`
+}
+
+func (tag Tag) Validate() error {
+	return validation.ValidateStruct(&tag,
+		validation.Field(&tag.Key, validation.Required, lengthIn0To200),
+		validation.Field(&tag.Value, lengthLessThan4096),
+	)
+}
 
 type Release struct {
 	Name      string     `json:"Name" bson:"_id"`
 	Modified  *time.Time `json:"Modified,omitempty" bson:"modified,omitempty"`
 	Artifacts []Image    `json:"Artifacts" bson:"artifacts"`
+	Tags      Tags       `json:"tags" bson:"tags,omitempty"`
 }
 
 type ReleaseOrImageFilter struct {

--- a/model/release_test.go
+++ b/model/release_test.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package model
+
+import (
+	"strconv"
+	"testing"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleaseTags(t *testing.T) {
+
+	tooLong := make(Tags, TagsPerReleaseMax+1)
+	for i := range tooLong {
+		tooLong[i].Key = strconv.Itoa(i)
+	}
+	err := tooLong.Validate()
+	assert.ErrorIs(t, err, ErrTooManyTags)
+
+	var emptyTag Tag
+	var errs validation.Errors
+	err = emptyTag.Validate()
+	assert.ErrorAs(t, err, &errs)
+}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -182,6 +182,11 @@ type DataStore interface {
 		ctx context.Context,
 		devicesIds []string,
 	) ([]model.DeviceDeploymentLastStatus, error)
+	ReplaceReleaseTags(
+		ctx context.Context,
+		releaseName string,
+		tags model.Tags,
+	) error
 }
 
 var ErrNotFound = errors.New("document not found")

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -182,11 +182,14 @@ type DataStore interface {
 		ctx context.Context,
 		devicesIds []string,
 	) ([]model.DeviceDeploymentLastStatus, error)
+
+	// Releases
 	ReplaceReleaseTags(
 		ctx context.Context,
 		releaseName string,
 		tags model.Tags,
 	) error
+	ListReleaseTagKeys(ctx context.Context) ([]string, error)
 }
 
 var ErrNotFound = errors.New("document not found")

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -1013,6 +1013,29 @@ func (_m *DataStore) ListImages(ctx context.Context, filt *model.ReleaseOrImageF
 	return r0, r1, r2
 }
 
+// ListReleaseTagKeys provides a mock function with given fields: ctx
+func (_m *DataStore) ListReleaseTagKeys(ctx context.Context) ([]string, error) {
+	ret := _m.Called(ctx)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Ping provides a mock function with given fields: ctx
 func (_m *DataStore) Ping(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -1041,6 +1041,20 @@ func (_m *DataStore) ProvisionTenant(ctx context.Context, tenantId string) error
 	return r0
 }
 
+// ReplaceReleaseTags provides a mock function with given fields: ctx, releaseName, tags
+func (_m *DataStore) ReplaceReleaseTags(ctx context.Context, releaseName string, tags model.Tags) error {
+	ret := _m.Called(ctx, releaseName, tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.Tags) error); ok {
+		r0 = rf(ctx, releaseName, tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SaveDeviceDeploymentLog provides a mock function with given fields: ctx, log
 func (_m *DataStore) SaveDeviceDeploymentLog(ctx context.Context, log model.DeploymentLog) error {
 	ret := _m.Called(ctx, log)

--- a/store/mongo/migration_1_2_16.go
+++ b/store/mongo/migration_1_2_16.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	mopts "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type migration_1_2_16 struct {
+	client *mongo.Client
+	db     string
+}
+
+// Up creates an index for filtering tags and retrieving distinct tag keys.
+func (m *migration_1_2_16) Up(from migrate.Version) error {
+	ctx := context.Background()
+	idxReleases := m.client.
+		Database(m.db).
+		Collection(CollectionReleases).
+		Indexes()
+
+	_, err := idxReleases.CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{
+			Key:   StorageKeyReleaseTagKey,
+			Value: 1,
+		}, {
+			Key:   StorageKeyReleaseTagValue,
+			Value: 1,
+		}},
+		Options: mopts.Index().
+			SetName(IndexNameReleaseTags),
+	})
+	if err != nil {
+		return fmt.Errorf("mongo(1.2.16): failed to create index: %w", err)
+	}
+	return nil
+}
+
+func (m *migration_1_2_16) Version() migrate.Version {
+	return migrate.MakeVersion(1, 2, 16)
+}

--- a/store/mongo/migrations.go
+++ b/store/mongo/migrations.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	DbVersion        = "1.2.15"
+	DbVersion        = "1.2.16"
 	DbMinimumVersion = "1.2.14"
 	DbName           = "deployment_service"
 )
@@ -131,6 +131,10 @@ func MigrateSingle(ctx context.Context,
 			db:     db,
 		},
 		&migration_1_2_15{
+			client: client,
+			db:     db,
+		},
+		&migration_1_2_16{
 			client: client,
 			db:     db,
 		},

--- a/store/mongo/migrations_test.go
+++ b/store/mongo/migrations_test.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package mongo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	mgopts "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestMigration_1_2_6(t *testing.T) {
+	ctx := context.Background()
+	client := db.Client()
+
+	t.Run("ok", func(t *testing.T) {
+		migration := &migration_1_2_16{
+			client: client,
+			db:     "deployments_test",
+		}
+		err := migration.Up(migrate.MakeVersion(1, 2, 15))
+		assert.NoError(t, err)
+		assert.Equal(t, migrate.MakeVersion(1, 2, 16), migration.Version())
+	})
+
+	t.Run("error/indexAlreadyExist", func(t *testing.T) {
+		collBadReleases := client.Database("deployments_test_bad").
+			Collection(CollectionReleases)
+		idxView := collBadReleases.Indexes()
+
+		// Create a bad index with the same name
+		_, _ = idxView.CreateOne(ctx, mongo.IndexModel{
+			Keys: bson.D{{
+				Key: "bad", Value: 1,
+			}},
+			Options: mgopts.Index().
+				SetName(IndexNameReleaseTags),
+		})
+
+		migration_fail := &migration_1_2_16{
+			client: client,
+			db:     "deployments_test_bad",
+		}
+		err := migration_fail.Up(migrate.MakeVersion(1, 2, 15))
+		var srvErr mongo.ServerError
+		assert.ErrorAs(t, err, &srvErr)
+	})
+}


### PR DESCRIPTION
:information_source: Since there is no way of adding a limit to the projection scan (mongodb does not collapse $group and $limit to do partial index scans), I added internal limits on the number of unique tags that can be assigned to releases.