### PR TITLE
MEN-6348: Add tags to releases

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -1953,7 +1953,6 @@ func (d *DeploymentsApiHandlers) PutReleaseTags(
 	w rest.ResponseWriter,
 	r *rest.Request,
 ) {
-	defer r.Body.Close()
 	ctx := r.Context()
 	l := log.FromContext(ctx)
 
@@ -1994,4 +1993,24 @@ func (d *DeploymentsApiHandlers) PutReleaseTags(
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (d *DeploymentsApiHandlers) GetReleaseTagKeys(
+	w rest.ResponseWriter,
+	r *rest.Request,
+) {
+	ctx := r.Context()
+	l := log.FromContext(ctx)
+
+	tags, err := d.app.ListReleaseTags(ctx)
+	if err != nil {
+		rest_utils.RestErrWithLog(w, r, l, err, http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	err = w.WriteJson(tags)
+	if err != nil {
+		l.Errorf("failed to serialize JSON response: %s", err.Error())
+	}
 }

--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -1942,6 +1943,53 @@ func (d *DeploymentsApiHandlers) PutTenantStorageSettingsHandler(
 	err = d.app.SetStorageSettings(ctx, settings)
 	if err != nil {
 		rest_utils.RestErrWithLogInternal(w, r, l, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (d *DeploymentsApiHandlers) PutReleaseTags(
+	w rest.ResponseWriter,
+	r *rest.Request,
+) {
+	defer r.Body.Close()
+	ctx := r.Context()
+	l := log.FromContext(ctx)
+
+	releaseName := r.PathParam(ParamName)
+	if releaseName == "" {
+		err := errors.New("path parameter 'release_name' cannot be empty")
+		rest_utils.RestErrWithLog(w, r, l, err, http.StatusNotFound)
+		return
+	}
+
+	var tags model.Tags
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&tags); err != nil {
+		rest_utils.RestErrWithLog(w, r, l,
+			errors.WithMessage(err,
+				"malformed JSON in request body"),
+			http.StatusBadRequest)
+		return
+	}
+	if err := tags.Validate(); err != nil {
+		rest_utils.RestErrWithLog(w, r, l,
+			errors.WithMessage(err,
+				"invalid request body"),
+			http.StatusBadRequest)
+		return
+	}
+
+	err := d.app.ReplaceReleaseTags(ctx, releaseName, tags)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, app.ErrReleaseNotFound) {
+			status = http.StatusNotFound
+		} else if errors.Is(err, model.ErrTooManyUniqueTags) {
+			status = http.StatusConflict
+		}
+		rest_utils.RestErrWithLog(w, r, l, err, status)
 		return
 	}
 

--- a/api/http/api_deployments_test.go
+++ b/api/http/api_deployments_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2576,6 +2577,241 @@ func TestListDeviceDeploymentsByIDsInternal(t *testing.T) {
 			if tc.responseCode == http.StatusOK {
 				assert.Equal(t, tc.deployments, res, "Unexpected response body")
 			}
+		})
+	}
+}
+
+func TestPutReleaseTags(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		Name string
+
+		App func(t *testing.T, self *testCase) *mapp.App
+		*http.Request
+
+		StatusCode int
+	}
+
+	testCases := []testCase{{
+		Name: "ok",
+
+		Request: func() *http.Request {
+			b, _ := json.Marshal(model.Tags{"one", "one", "two", "three"})
+
+			req, _ := http.NewRequest(
+				http.MethodPut,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTags, "#name", "release-mc-release-face")),
+				bytes.NewReader(b),
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			appie := new(mapp.App)
+			expectedTags := model.Tags{"one", "three", "two"}
+			appie.On("ReplaceReleaseTags",
+				contextMatcher(),
+				"release-mc-release-face",
+				expectedTags).
+				Return(nil)
+			return appie
+		},
+
+		StatusCode: http.StatusNoContent,
+	}, {
+		Name: "error/internal",
+
+		Request: func() *http.Request {
+			b, _ := json.Marshal(model.Tags{"one", "two", "three"})
+
+			req, _ := http.NewRequest(
+				http.MethodPut,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTags, "#name", "release-mc-release-face")),
+				bytes.NewReader(b),
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			appie := new(mapp.App)
+			expectedTags := model.Tags{"one", "three", "two"}
+			appie.On("ReplaceReleaseTags",
+				contextMatcher(),
+				"release-mc-release-face",
+				expectedTags).
+				Return(errors.New("internal error"))
+			return appie
+		},
+
+		StatusCode: http.StatusInternalServerError,
+	}, {
+		Name: "error/too many unique tags",
+
+		Request: func() *http.Request {
+			b, _ := json.Marshal(model.Tags{"one", "two", "three"})
+
+			req, _ := http.NewRequest(
+				http.MethodPut,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTags, "#name", "release-mc-release-face")),
+				bytes.NewReader(b),
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			appie := new(mapp.App)
+			expectedTags := model.Tags{"one", "three", "two"}
+			appie.On("ReplaceReleaseTags",
+				contextMatcher(),
+				"release-mc-release-face",
+				expectedTags).
+				Return(model.ErrTooManyUniqueTags)
+			return appie
+		},
+
+		StatusCode: http.StatusConflict,
+	}, {
+		Name: "error/release not found",
+
+		Request: func() *http.Request {
+			b, _ := json.Marshal(model.Tags{"one", "two", "three"})
+
+			req, _ := http.NewRequest(
+				http.MethodPut,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTags, "#name", "release-mc-release-face")),
+				bytes.NewReader(b),
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			appie := new(mapp.App)
+			expectedTags := model.Tags{"one", "three", "two"}
+			appie.On("ReplaceReleaseTags",
+				contextMatcher(),
+				"release-mc-release-face",
+				expectedTags).
+				Return(app.ErrReleaseNotFound)
+			return appie
+		},
+
+		StatusCode: http.StatusNotFound,
+	}, {
+		Name: "error/too many tags",
+
+		Request: func() *http.Request {
+			tags := make(model.Tags, model.TagsMaxPerRelease+1)
+			for i := range tags {
+				tags[i] = model.Tag("field" + strconv.Itoa(i))
+			}
+			b, _ := json.Marshal(tags)
+
+			req, _ := http.NewRequest(
+				http.MethodPut,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTags, "#name", "release-mc-release-face")),
+				bytes.NewReader(b),
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			return new(mapp.App)
+		},
+
+		StatusCode: http.StatusBadRequest,
+	}, {
+		Name: "ok/many duplicate tags",
+
+		Request: func() *http.Request {
+			tags := make(model.Tags, model.TagsMaxPerRelease+1)
+			for i := range tags {
+				tags[i] = model.Tag("field")
+			}
+			b, _ := json.Marshal(tags)
+
+			req, _ := http.NewRequest(
+				http.MethodPut,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTags, "#name", "release-mc-release-face")),
+				bytes.NewReader(b),
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			appie := new(mapp.App)
+			expectedTags := model.Tags{"field"}
+			appie.On("ReplaceReleaseTags",
+				contextMatcher(),
+				"release-mc-release-face",
+				expectedTags).
+				Return(nil)
+			return appie
+		},
+
+		StatusCode: http.StatusNoContent,
+	}, {
+		Name: "error/malformed JSON",
+
+		Request: func() *http.Request {
+			req, _ := http.NewRequest(
+				http.MethodPut,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTags, "#name", "release-mc-release-face")),
+				bytes.NewReader([]byte("not json")),
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			return new(mapp.App)
+		},
+
+		StatusCode: http.StatusBadRequest,
+	}, {
+		Name: "error/empty release name",
+
+		Request: func() *http.Request {
+			req, _ := http.NewRequest(
+				http.MethodPut,
+				fmt.Sprintf("http://localhost:1234%s",
+					strings.ReplaceAll(ApiUrlManagementV2ReleaseTags, "#name", "")),
+				bytes.NewReader([]byte("[]")),
+			)
+			return req
+		}(),
+
+		App: func(t *testing.T, self *testCase) *mapp.App {
+			return new(mapp.App)
+		},
+
+		StatusCode: http.StatusNotFound,
+	}}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			appie := tc.App(t, &tc)
+			defer appie.AssertExpectations(t)
+
+			handlers := NewDeploymentsApiHandlers(nil, &view.RESTView{}, appie)
+			routes := ReleasesRoutes(handlers)
+			router, _ := rest.MakeRouter(routes...)
+			api := rest.NewApi()
+			api.SetApp(router)
+			handler := api.MakeHandler()
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, tc.Request)
+
+			rsp := w.Result()
+			assert.Equal(t, tc.StatusCode, rsp.StatusCode,
+				"unexpected status code from request")
 		})
 	}
 }

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -62,6 +62,9 @@ const (
 
 	ApiUrlManagementLimitsName = ApiUrlManagement + "/limits/#name"
 
+	ApiUrlManagementV2            = "/api/management/v2/deployments"
+	ApiUrlManagementV2ReleaseTags = ApiUrlManagementV2 + "/releases/#name/tags"
+
 	ApiUrlDevicesDeploymentsNext  = ApiUrlDevices + "/device/deployments/next"
 	ApiUrlDevicesDeploymentStatus = ApiUrlDevices + "/device/deployments/#id/status"
 	ApiUrlDevicesDeploymentsLog   = ApiUrlDevices + "/device/deployments/#id/log"
@@ -252,6 +255,7 @@ func ReleasesRoutes(controller *DeploymentsApiHandlers) []*rest.Route {
 	return []*rest.Route{
 		rest.Get(ApiUrlManagementReleases, controller.GetReleases),
 		rest.Get(ApiUrlManagementReleasesList, controller.ListReleases),
+		rest.Put(ApiUrlManagementV2ReleaseTags, controller.PutReleaseTags),
 	}
 }
 

--- a/api/http/routing.go
+++ b/api/http/routing.go
@@ -62,8 +62,9 @@ const (
 
 	ApiUrlManagementLimitsName = ApiUrlManagement + "/limits/#name"
 
-	ApiUrlManagementV2            = "/api/management/v2/deployments"
-	ApiUrlManagementV2ReleaseTags = ApiUrlManagementV2 + "/releases/#name/tags"
+	ApiUrlManagementV2               = "/api/management/v2/deployments"
+	ApiUrlManagementV2ReleaseTags    = ApiUrlManagementV2 + "/releases/#name/tags"
+	ApiUrlManagementV2ReleaseAllTags = ApiUrlManagementV2 + "/releases/all/tags"
 
 	ApiUrlDevicesDeploymentsNext  = ApiUrlDevices + "/device/deployments/next"
 	ApiUrlDevicesDeploymentStatus = ApiUrlDevices + "/device/deployments/#id/status"
@@ -256,6 +257,7 @@ func ReleasesRoutes(controller *DeploymentsApiHandlers) []*rest.Route {
 		rest.Get(ApiUrlManagementReleases, controller.GetReleases),
 		rest.Get(ApiUrlManagementReleasesList, controller.ListReleases),
 		rest.Put(ApiUrlManagementV2ReleaseTags, controller.PutReleaseTags),
+		rest.Get(ApiUrlManagementV2ReleaseAllTags, controller.GetReleaseTagKeys),
 	}
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -192,6 +192,7 @@ type App interface {
 
 	// releases
 	ReplaceReleaseTags(ctx context.Context, releaseName string, tags model.Tags) error
+	ListReleaseTags(ctx context.Context) (model.Tags, error)
 }
 
 type Deployments struct {
@@ -2115,6 +2116,16 @@ func (d *Deployments) updateRelease(
 	}
 
 	return d.db.UpdateReleaseArtifacts(ctx, artifactToAdd, artifactToRemove, name)
+}
+
+func (d *Deployments) ListReleaseTags(ctx context.Context) (model.Tags, error) {
+	tags, err := d.db.ListReleaseTags(ctx)
+	if err != nil {
+		log.FromContext(ctx).
+			Errorf("failed to list release tags: %s", err)
+		err = ErrModelInternal
+	}
+	return tags, err
 }
 
 func (d *Deployments) ReplaceReleaseTags(

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -650,6 +650,29 @@ func (_m *App) ListImages(ctx context.Context, filters *model.ReleaseOrImageFilt
 	return r0, r1, r2
 }
 
+// ListReleaseTags provides a mock function with given fields: ctx
+func (_m *App) ListReleaseTags(ctx context.Context) (model.Tags, error) {
+	ret := _m.Called(ctx)
+
+	var r0 model.Tags
+	if rf, ok := ret.Get(0).(func(context.Context) model.Tags); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(model.Tags)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LookupDeployment provides a mock function with given fields: ctx, query
 func (_m *App) LookupDeployment(ctx context.Context, query model.Query) ([]*model.Deployment, int64, error) {
 	ret := _m.Called(ctx, query)

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -269,27 +269,6 @@ func (_m *App) GenerateImage(ctx context.Context, multipartUploadMsg *model.Mult
 	return r0, r1
 }
 
-// GetDeviceDeploymentLastStatus provides a mock function with given fields: ctx, devicesIds
-func (_m *App) GetDeviceDeploymentLastStatus(ctx context.Context, devicesIds []string) (model.DeviceDeploymentLastStatuses, error) {
-	ret := _m.Called(ctx, devicesIds)
-
-	var r0 model.DeviceDeploymentLastStatuses
-	if rf, ok := ret.Get(0).(func(context.Context, []string) model.DeviceDeploymentLastStatuses); ok {
-		r0 = rf(ctx, devicesIds)
-	} else {
-		r0 = ret.Get(0).(model.DeviceDeploymentLastStatuses)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
-		r1 = rf(ctx, devicesIds)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetDeployment provides a mock function with given fields: ctx, deploymentID
 func (_m *App) GetDeployment(ctx context.Context, deploymentID string) (*model.Deployment, error) {
 	ret := _m.Called(ctx, deploymentID)
@@ -382,6 +361,27 @@ func (_m *App) GetDeploymentsStats(ctx context.Context, deploymentIDs ...string)
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, ...string) error); ok {
 		r1 = rf(ctx, deploymentIDs...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetDeviceDeploymentLastStatus provides a mock function with given fields: ctx, devicesIds
+func (_m *App) GetDeviceDeploymentLastStatus(ctx context.Context, devicesIds []string) (model.DeviceDeploymentLastStatuses, error) {
+	ret := _m.Called(ctx, devicesIds)
+
+	var r0 model.DeviceDeploymentLastStatuses
+	if rf, ok := ret.Get(0).(func(context.Context, []string) model.DeviceDeploymentLastStatuses); ok {
+		r0 = rf(ctx, devicesIds)
+	} else {
+		r0 = ret.Get(0).(model.DeviceDeploymentLastStatuses)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = rf(ctx, devicesIds)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -687,6 +687,20 @@ func (_m *App) ProvisionTenant(ctx context.Context, tenant_id string) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(ctx, tenant_id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ReplaceReleaseTags provides a mock function with given fields: ctx, releaseName, tags
+func (_m *App) ReplaceReleaseTags(ctx context.Context, releaseName string, tags model.Tags) error {
+	ret := _m.Called(ctx, releaseName, tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.Tags) error); ok {
+		r0 = rf(ctx, releaseName, tags)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -2184,6 +2184,14 @@ definitions:
         description: List of artifacts for this release.
         items:
           $ref: "#/definitions/Artifact"
+      tags:
+        type: array
+        description: |-
+          Tags assigned to the release used for filtering releases. Each tag
+          must be valid a ASCII string and contain only lowercase and uppercase
+          letters, digits, underscores, periods and hyphens.
+        items:
+          type: string
     example:
       name: my-app-v1.0.1
       artifacts:

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -46,7 +46,7 @@ responses:
 paths:
   /deployments/releases/{release_name}/tags:
     put:
-      operationId: Replace release tags
+      operationId: Assign Release Tags
       tags:
         - Management API
       security:
@@ -54,8 +54,12 @@ paths:
       summary: |
         Update and replace the tags of a release.
       description: |
-        Returns a collection of releases, allows filtering by release name and sorting
-        by name or last modification date.
+        Assigns tags to releases. The tags will be replaced with the ones
+        defined in the request body.
+
+        LIMITATIONS:
+          * Max 20 tags can be assigned to a single release.
+          * There can be no more than 100 unique tag keys in total.
       parameters:
         - name: release_name
           in: path

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -1,0 +1,110 @@
+swagger: '2.0'
+info:
+  title: Deployments v2
+  version: '2'
+  description: |
+    Version 2 of the API for deployments management.
+    Intended for use by the web GUI.
+
+host: 'hosted.mender.io'
+basePath: '/api/management/v2/deployments'
+schemes:
+  - https
+
+consumes:
+  - application/json
+produces:
+  - application/json
+
+securityDefinitions:
+  ManagementJWT:
+    type: apiKey
+    in: header
+    name: Authorization
+    description: |
+      API token issued by User Authentication service.
+      Format: 'Bearer [JWT]'
+
+responses:
+  InvalidRequestError: # 400
+    description: Bad request, see error message for details.
+    schema:
+      $ref: "#/definitions/Error"
+  UnauthorizedError: # 401
+    description: Unauthorized.
+    schema:
+      $ref: "#/definitions/Error"
+  UnprocessableEntityError: # 422
+    description: Unprocessable Entity.
+    schema:
+      $ref: "#/definitions/Error"
+  InternalServerError: # 500
+    description: Internal Server Error.
+    schema:
+      $ref: "#/definitions/Error"
+
+paths:
+  /deployments/releases/{release_name}/tags:
+    put:
+      operationId: Replace release tags
+      tags:
+        - Management API
+      security:
+        - ManagementJWT: []
+      summary: |
+        Update and replace the tags of a release.
+      description: |
+        Returns a collection of releases, allows filtering by release name and sorting
+        by name or last modification date.
+      parameters:
+        - name: release_name
+          in: path
+          description: Name of the release
+          required: true
+          type: string
+        - name: tags
+          in: body
+          schema:
+            $ref: "#/definitions/Tags"
+      produces:
+        - application/json
+      responses:
+        204:
+          description: Successful response.
+        400:
+          $ref: "#/responses/InvalidRequestError"
+        401:
+          $ref: "#/responses/UnauthorizedError"
+        409:
+          description: Too many unique tag keys in use.
+          schema:
+            $ref: "#/definitions/Error"
+
+          examples:
+            application/json:
+              error: "the total number of unique tags has been exceeded"
+              request_id: "f7881e82-0492-49fb-b459-795654e7188a"
+        500:
+          $ref: "#/responses/InternalServerError"
+
+
+definitions:
+  Tags:
+    description: Filter tags
+    type: array
+    items:
+      type: string
+
+  Error:
+    description: Error descriptor.
+    type: object
+    properties:
+      error:
+        description: Description of the error.
+        type: string
+      request_id:
+        description: Request ID (same as in X-MEN-RequestID header).
+        type: string
+    example:
+      error: "failed to decode device group data: JSON payload is empty"
+      request_id: "f7881e82-0492-49fb-b459-795654e7188a"

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -4,7 +4,7 @@ info:
   version: '2'
   description: |
     Version 2 of the API for deployments management.
-    Intended for use by the web GUI.
+    Intended for use by the web UI.
 
 host: 'hosted.mender.io'
 basePath: '/api/management/v2/deployments'
@@ -54,8 +54,8 @@ paths:
       summary: |
         Update and replace the tags of a release.
       description: |
-        Assigns tags to releases. The tags will be replaced with the ones
-        defined in the request body.
+        Assigns tags to a release. The tags associated with the release will be
+        replaced with the ones defined in the request body.
 
         LIMITATIONS:
           * Max 20 tags can be assigned to a single release.
@@ -91,11 +91,46 @@ paths:
         500:
           $ref: "#/responses/InternalServerError"
 
+  /deployments/releases/all/tags:
+    get:
+      operationId: List Release Tags
+      tags:
+        - Management API
+      security:
+        - ManagementJWT: []
+      summary: |
+        Lists all available tags for releases.
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Successful response.
+          schema:
+            $ref: "#/definitions/Tags"
+        400:
+          $ref: "#/responses/InvalidRequestError"
+        401:
+          $ref: "#/responses/UnauthorizedError"
+        409:
+          description: Too many unique tag keys in use.
+          schema:
+            $ref: "#/definitions/Error"
+
+          examples:
+            application/json:
+              error: "the total number of unique tags has been exceeded"
+              request_id: "f7881e82-0492-49fb-b459-795654e7188a"
+        500:
+          $ref: "#/responses/InternalServerError"
+
 
 definitions:
   Tags:
-    description: Filter tags
     type: array
+    description: |-
+      Tags assigned to the release used for filtering releases. Each tag
+      must be valid a ASCII string and contain only lowercase and uppercase
+      letters, digits, underscores, periods and hyphens.
     items:
       type: string
 

--- a/model/release.go
+++ b/model/release.go
@@ -11,14 +11,120 @@
 //	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //	See the License for the specific language governing permissions and
 //	limitations under the License.
+
 package model
 
-import "time"
+import (
+	"encoding/json"
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	TagsMaxPerRelease = 20  // Maximum number of tags per release.
+	TagsMaxUnique     = 100 // Maximum number of unique tags.
+)
+
+var (
+	ErrTooManyTags = errors.New(
+		"the total number of tags per exceeded maximum of " +
+			strconv.Itoa(TagsMaxPerRelease),
+	)
+	ErrTooManyUniqueTags = errors.New(
+		"the total number of unique tags (" +
+			strconv.Itoa(TagsMaxUnique) +
+			") has been exceeded",
+	)
+)
+
+type Tags []Tag
+
+func (tags Tags) Validate() (err error) {
+	if len(tags) > TagsMaxPerRelease {
+		return ErrTooManyTags
+	}
+	for _, tag := range tags {
+		if err = tag.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tags Tags) MarshalJSON() ([]byte, error) {
+	if len(tags) == 0 {
+		return []byte{'[', ']'}, nil
+	}
+	return json.Marshal([]Tag(tags))
+}
+
+func (tags *Tags) Dedup() {
+	// Deduplicate tags:
+	s := *tags
+	sort.Slice(s, func(i, j int) bool {
+		return s[i] < s[j]
+	})
+	i, j := 0, 0
+	for j < len(s) {
+		if s[i] != s[j] {
+			i++
+			s[i] = s[j]
+		}
+		j++
+	}
+	*tags = s[:i+1]
+}
+
+func (tags *Tags) UnmarshalJSON(b []byte) error {
+	err := json.Unmarshal(b, (*[]Tag)(tags))
+	if err != nil {
+		return err
+	}
+	tags.Dedup()
+	return nil
+}
+
+type Tag string
+
+const (
+	TagMaxLength = 1024
+)
+
+var (
+	ErrTagEmpty   = errors.New("tag cannot be empty")
+	ErrTagTooLong = errors.New("tag must be less than " +
+		strconv.Itoa(TagMaxLength) +
+		" characters")
+)
+
+func (tag Tag) Validate() error {
+	if len(tag) < 1 {
+		return ErrTagEmpty
+	} else if len(tag) > TagMaxLength {
+		return ErrTagTooLong
+	}
+	return nil
+}
+
+func (tag *Tag) UnmarshalJSON(b []byte) error {
+	// Convert tag to lower case
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*tag = Tag(strings.ToLower(s))
+	return nil
+}
 
 type Release struct {
 	Name      string     `json:"Name" bson:"_id"`
 	Modified  *time.Time `json:"Modified,omitempty" bson:"modified,omitempty"`
 	Artifacts []Image    `json:"Artifacts" bson:"artifacts"`
+	Tags      Tags       `json:"tags" bson:"tags,omitempty"`
 }
 
 type ReleaseOrImageFilter struct {

--- a/model/release.go
+++ b/model/release.go
@@ -17,6 +17,7 @@ package model
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -100,11 +101,36 @@ var (
 		" characters")
 )
 
+type InvalidCharacterError struct {
+	Source string
+	Char   rune
+}
+
+func (err *InvalidCharacterError) Error() string {
+	return fmt.Sprintf(`invalid character '%c' in string "%s"`, err.Char, err.Source)
+}
+
 func (tag Tag) Validate() error {
 	if len(tag) < 1 {
 		return ErrTagEmpty
 	} else if len(tag) > TagMaxLength {
 		return ErrTagTooLong
+	}
+	for _, c := range tag { // [A-Za-z0-9-_.]
+		if c >= 'A' && c <= 'Z' {
+			continue
+		} else if c >= 'a' && c <= 'z' {
+			continue
+		} else if c >= '0' && c <= '9' {
+			continue
+		} else if c == '-' || c == '_' || c == '.' {
+			continue
+		} else {
+			return &InvalidCharacterError{
+				Source: string(tag),
+				Char:   c,
+			}
+		}
 	}
 	return nil
 }

--- a/model/release_test.go
+++ b/model/release_test.go
@@ -1,0 +1,50 @@
+// Copyright 2023 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReleaseTags(t *testing.T) {
+
+	tooLong := make(Tags, TagsMaxPerRelease+1)
+	for i := range tooLong {
+		tooLong[i] = Tag(strconv.Itoa(i))
+	}
+	err := tooLong.Validate()
+	assert.ErrorIs(t, err, ErrTooManyTags)
+
+	var emptyTag Tag
+	err = emptyTag.Validate()
+	assert.ErrorIs(t, err, ErrTagEmpty)
+
+	t.Run("unmarshal tags", func(t *testing.T) {
+		var tags Tags
+		err := json.Unmarshal(
+			[]byte(`["tag", "tag", "more-tags"]`),
+			&tags,
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, Tags{"more-tags", "tag"}, tags)
+
+		err = json.Unmarshal([]byte(`{}`), &tags)
+		assert.Error(t, err)
+	})
+}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -182,6 +182,11 @@ type DataStore interface {
 		ctx context.Context,
 		devicesIds []string,
 	) ([]model.DeviceDeploymentLastStatus, error)
+	ReplaceReleaseTags(
+		ctx context.Context,
+		releaseName string,
+		tags model.Tags,
+	) error
 }
 
 var ErrNotFound = errors.New("document not found")

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -182,11 +182,14 @@ type DataStore interface {
 		ctx context.Context,
 		devicesIds []string,
 	) ([]model.DeviceDeploymentLastStatus, error)
+
+	// Releases
 	ReplaceReleaseTags(
 		ctx context.Context,
 		releaseName string,
 		tags model.Tags,
 	) error
+	ListReleaseTags(ctx context.Context) (model.Tags, error)
 }
 
 var ErrNotFound = errors.New("document not found")

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -1041,6 +1041,20 @@ func (_m *DataStore) ProvisionTenant(ctx context.Context, tenantId string) error
 	return r0
 }
 
+// ReplaceReleaseTags provides a mock function with given fields: ctx, releaseName, tags
+func (_m *DataStore) ReplaceReleaseTags(ctx context.Context, releaseName string, tags model.Tags) error {
+	ret := _m.Called(ctx, releaseName, tags)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.Tags) error); ok {
+		r0 = rf(ctx, releaseName, tags)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SaveDeviceDeploymentLog provides a mock function with given fields: ctx, log
 func (_m *DataStore) SaveDeviceDeploymentLog(ctx context.Context, log model.DeploymentLog) error {
 	ret := _m.Called(ctx, log)

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -1013,6 +1013,29 @@ func (_m *DataStore) ListImages(ctx context.Context, filt *model.ReleaseOrImageF
 	return r0, r1, r2
 }
 
+// ListReleaseTags provides a mock function with given fields: ctx
+func (_m *DataStore) ListReleaseTags(ctx context.Context) (model.Tags, error) {
+	ret := _m.Called(ctx)
+
+	var r0 model.Tags
+	if rf, ok := ret.Get(0).(func(context.Context) model.Tags); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(model.Tags)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Ping provides a mock function with given fields: ctx
 func (_m *DataStore) Ping(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -62,6 +62,10 @@ const (
 	errorCodeIndexNotFound     = 27
 )
 
+const (
+	mongoOpSet = "$set"
+)
+
 var currentDbVersion map[string]*migrate.Version
 
 var (
@@ -93,8 +97,8 @@ var (
 	// Indexes 1.2.13
 	IndexArtifactProvidesName = "artifact_provides"
 
-	// Indexes 1.2.15
-	IndexReleaseNameName = "release_name"
+	// Indexes 1.2.16
+	IndexNameReleaseTags = "release_tags"
 
 	_false         = false
 	_true          = true
@@ -403,6 +407,7 @@ const (
 	// releases
 	StorageKeyReleaseName                      = "_id"
 	StorageKeyReleaseModified                  = "modified"
+	StorageKeyReleaseTags                      = "tags"
 	StorageKeyReleaseArtifacts                 = "artifacts"
 	StorageKeyReleaseArtifactsIndexDescription = StorageKeyReleaseArtifacts + ".$." +
 		StorageKeyImageDescription
@@ -2962,6 +2967,76 @@ func (db *DataStoreMongo) UpdateReleaseArtifacts(
 	)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func (db *DataStoreMongo) ListReleaseTags(ctx context.Context) (model.Tags, error) {
+	l := log.FromContext(ctx)
+	tagKeys, err := db.client.
+		Database(mstore.DbFromContext(ctx, DatabaseName)).
+		Collection(CollectionReleases).
+		Distinct(ctx, StorageKeyReleaseTags, bson.D{})
+	if err != nil {
+		return nil, errors.WithMessage(err,
+			"mongo: failed to retrieve distinct tags")
+	}
+	ret := make([]model.Tag, 0, len(tagKeys))
+	for _, elem := range tagKeys {
+		if key, ok := elem.(string); ok {
+			ret = append(ret, model.Tag(key))
+		} else {
+			l.Warnf("unexpected data type (%T) received from distinct call: "+
+				"ignoring result", elem)
+		}
+	}
+
+	return ret, err
+}
+
+func (db *DataStoreMongo) ReplaceReleaseTags(
+	ctx context.Context,
+	releaseName string,
+	tags model.Tags,
+) error {
+	// Check preconditions
+	if len(tags) > model.TagsMaxUnique {
+		return model.ErrTooManyUniqueTags
+	}
+
+	collReleases := db.client.
+		Database(mstore.DbFromContext(ctx, DatabaseName)).
+		Collection(CollectionReleases)
+
+	// Check if added tags will exceed limits
+	if len(tags) > 0 {
+		inUseTags, err := db.ListReleaseTags(ctx)
+		if err != nil {
+			return errors.WithMessage(err, "mongo: failed to count in-use tags")
+		}
+		tagSet := make(map[model.Tag]struct{}, len(inUseTags))
+		for _, tagKey := range inUseTags {
+			tagSet[tagKey] = struct{}{}
+		}
+		for _, tag := range tags {
+			delete(tagSet, tag)
+		}
+		if len(tags)+len(tagSet) > model.TagsMaxUnique {
+			return model.ErrTooManyUniqueTags
+		}
+	}
+
+	// Update release tags
+	res, err := collReleases.UpdateOne(ctx, bson.D{{
+		Key: StorageKeyReleaseName, Value: releaseName,
+	}}, bson.D{{
+		Key:   mongoOpSet,
+		Value: bson.D{{Key: StorageKeyReleaseTags, Value: tags}},
+	}})
+	if err != nil {
+		return errors.WithMessage(err, "mongo: failed to update release tags")
+	} else if res.MatchedCount <= 0 {
+		return store.ErrNotFound
 	}
 	return nil
 }

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -16,6 +16,8 @@ package mongo
 
 import (
 	"context"
+	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -27,8 +29,13 @@ import (
 	"github.com/mendersoftware/deployments/model"
 	"github.com/mendersoftware/deployments/store"
 	"github.com/mendersoftware/go-lib-micro/identity"
+	"github.com/mendersoftware/go-lib-micro/log"
 	ctxstore "github.com/mendersoftware/go-lib-micro/store"
 )
+
+func init() {
+	log.Log.Out = io.Discard
+}
 
 func TestPing(t *testing.T) {
 	if testing.Short() {
@@ -2369,6 +2376,278 @@ func TestIncrementDeploymentTotalSize(t *testing.T) {
 				deployments, _, err := ds.Find(ctx, model.Query{})
 				assert.NoError(t, err)
 				assert.Equal(t, tc.outputDeployments, deployments)
+			}
+		})
+	}
+}
+
+func TestReplaceReleaseTags(t *testing.T) {
+	ctx := context.Background()
+	client := db.Client()
+	db.Wipe()
+
+	type testCase struct {
+		Name string
+
+		context.Context
+
+		Init        func(t *testing.T, self *testCase)
+		ReleaseName string
+
+		Tags model.Tags
+
+		assert.ErrorAssertionFunc
+	}
+
+	testCases := []testCase{{
+		Name: "ok",
+
+		Context: context.Background(),
+
+		Init: func(t *testing.T, self *testCase) {
+			t.Helper()
+			_, err := client.Database(DbName).
+				Collection(CollectionReleases).
+				InsertMany(ctx, []interface{}{model.Release{
+					Name: self.ReleaseName,
+					Tags: model.Tags{"bar", "foo"},
+				}, model.Release{
+					Name: "v100.2.3",
+					Tags: model.Tags{"bar", "baz"},
+				}})
+			if err != nil {
+				t.Errorf("failed to initialize dataset: %s", err)
+				t.FailNow()
+			}
+		},
+		Tags: func() model.Tags {
+			newTags := make(model.Tags, model.TagsMaxUnique/2)
+			for i := range newTags {
+				newTags[i] = model.Tag("field" + strconv.Itoa(i))
+			}
+			return newTags
+		}(),
+		ReleaseName: "v1.0",
+	}, {
+		Name: "clear tags",
+
+		Context: identity.WithContext(context.Background(),
+			&identity.Identity{
+				Tenant: "111111111111111111111111",
+			},
+		),
+
+		Init: func(t *testing.T, self *testCase) {
+			t.Helper()
+			_, err := client.Database(ctxstore.DbFromContext(self, DbName)).
+				Collection(CollectionReleases).
+				InsertMany(self,
+					[]interface{}{model.Release{
+						Name: self.ReleaseName,
+						Tags: func() model.Tags {
+							newTags := make(model.Tags, model.TagsMaxUnique)
+							for i := range newTags {
+								newTags[i] = model.Tag(
+									"field" + strconv.Itoa(i),
+								)
+							}
+							return newTags
+						}(),
+					}, model.Release{
+						Name: "v1.2.3-beta",
+						Tags: model.Tags{"bar", "foo"},
+					}})
+			if err != nil {
+				t.Errorf("failed to initialize dataset: %s", err)
+				t.FailNow()
+			}
+		},
+		Tags:        model.Tags{},
+		ReleaseName: "v1.0",
+	}, {
+		Name: "error/too many tags",
+
+		Context: identity.WithContext(context.Background(),
+			&identity.Identity{
+				Tenant: "222222222222222222222222",
+			},
+		),
+
+		Init: func(t *testing.T, self *testCase) {
+			t.Helper()
+			_, err := client.Database(ctxstore.DbFromContext(self, DbName)).
+				Collection(CollectionReleases).
+				InsertMany(self,
+					[]interface{}{model.Release{
+						Name: self.ReleaseName,
+						Tags: func() model.Tags {
+							newTags := make(model.Tags, model.TagsMaxUnique)
+							for i := range newTags {
+								newTags[i] = model.Tag(
+									"field" + strconv.Itoa(i),
+								)
+							}
+							return newTags
+						}(),
+					}, model.Release{
+						Name: "v1.2.3-beta",
+						Tags: model.Tags{"bar", "foo"},
+					}})
+			if err != nil {
+				t.Errorf("failed to initialize dataset: %s", err)
+				t.FailNow()
+			}
+		},
+		Tags:        model.Tags{"oneFieldTooMany"},
+		ReleaseName: "v1.0",
+		ErrorAssertionFunc: func(t assert.TestingT, err error, vargs ...interface{}) bool {
+			return assert.ErrorIs(t, err, model.ErrTooManyUniqueTags)
+		},
+	}, {
+		Name: "error/too many tags in input",
+
+		Context: identity.WithContext(context.Background(),
+			&identity.Identity{
+				Tenant: "333333333333333333333333",
+			},
+		),
+
+		Init: func(t *testing.T, self *testCase) {
+			t.Helper()
+			_, err := client.Database(ctxstore.DbFromContext(self, DbName)).
+				Collection(CollectionReleases).
+				InsertMany(self,
+					[]interface{}{model.Release{
+						Name: self.ReleaseName,
+						Tags: model.Tags{},
+					}, model.Release{
+						Name: "v1.2.3-beta",
+						Tags: model.Tags{"bar", "foo"},
+					}})
+			if err != nil {
+				t.Errorf("failed to initialize dataset: %s", err)
+				t.FailNow()
+			}
+		},
+		Tags: func() model.Tags {
+			newTags := make(model.Tags, model.TagsMaxUnique+1)
+			for i := range newTags {
+				newTags[i] = model.Tag(
+					"field" + strconv.Itoa(i),
+				)
+			}
+			return newTags
+		}(),
+		ReleaseName: "v1.0",
+		ErrorAssertionFunc: func(t assert.TestingT, err error, vargs ...interface{}) bool {
+			return assert.ErrorIs(t, err, model.ErrTooManyUniqueTags)
+		},
+	}, {
+		Name: "error/no documents",
+
+		Context: context.Background(),
+		Init:    func(t *testing.T, self *testCase) {},
+
+		Tags:        model.Tags{},
+		ReleaseName: "not_found",
+		ErrorAssertionFunc: func(t assert.TestingT, err error, vargs ...interface{}) bool {
+			return assert.ErrorIs(t, err, store.ErrNotFound)
+		},
+	}, {
+		Name: "error/aggregate/decode error",
+
+		Context: identity.WithContext(ctx, &identity.Identity{
+			Tenant: "deadbeefdeadbeefdeadbeef",
+		}),
+		Init: func(t *testing.T, self *testCase) {
+			t.Helper()
+			_, err := client.Database(ctxstore.DbFromContext(self, DbName)).
+				Collection(CollectionReleases).
+				InsertMany(self,
+					[]interface{}{model.Release{
+						Name: self.ReleaseName,
+						Tags: model.Tags{},
+					}, map[string]interface{}{
+						StorageKeyReleaseName: "v1.2.3-beta",
+						StorageKeyReleaseTags: []map[string]interface{}{{
+							"key":   123,
+							"value": true,
+						}},
+					}})
+			if err != nil {
+				t.Errorf("failed to initialize dataset: %s", err)
+				t.FailNow()
+			}
+		},
+
+		Tags:        model.Tags{"bar", "foo"},
+		ReleaseName: "v1.0",
+	}, {
+		Name: "error/aggregate context cancelled",
+
+		Context: func() context.Context {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			return ctx
+		}(),
+		Init: func(t *testing.T, self *testCase) {},
+
+		Tags:        model.Tags{"oneMore", "tag"},
+		ReleaseName: "v1.0",
+		ErrorAssertionFunc: func(t assert.TestingT, err error, vargs ...interface{}) bool {
+			return assert.ErrorIs(t, err, context.Canceled)
+		},
+	}, {
+		Name: "error/update context cancelled",
+
+		Context: func() context.Context {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			return ctx
+		}(),
+		Init: func(t *testing.T, self *testCase) {},
+
+		Tags:        model.Tags{},
+		ReleaseName: "v1.0",
+		ErrorAssertionFunc: func(t assert.TestingT, err error, vargs ...interface{}) bool {
+			return assert.ErrorIs(t, err, context.Canceled)
+		},
+	}}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			var tenantID string
+			if id := identity.FromContext(tc.Context); id != nil {
+				tenantID = id.Tenant
+			}
+			err := MigrateSingle(ctx,
+				ctxstore.DbNameForTenant(tenantID, DbName),
+				DbVersion,
+				client,
+				true)
+			if err != nil {
+				panic(err)
+			}
+			tc.Init(t, &tc)
+
+			ds := NewDataStoreMongoWithClient(client)
+			err = ds.ReplaceReleaseTags(tc.Context, tc.ReleaseName, tc.Tags)
+			if tc.ErrorAssertionFunc == nil {
+				if assert.NoError(t, err) {
+					var release model.Release
+					err := client.Database(
+						ctxstore.DbNameForTenant(tenantID, DbName)).
+						Collection(CollectionReleases).
+						FindOne(ctx, bson.D{}).
+						Decode(&release)
+					if assert.NoError(t, err, "failed to decode updated release") {
+						assert.EqualValues(t, tc.Tags, release.Tags)
+					}
+				}
+			} else {
+				tc.ErrorAssertionFunc(t, err)
 			}
 		})
 	}

--- a/store/mongo/migration_1_2_16.go
+++ b/store/mongo/migration_1_2_16.go
@@ -1,0 +1,60 @@
+// Copyright 2023 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	mopts "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type migration_1_2_16 struct {
+	client *mongo.Client
+	db     string
+}
+
+// Up creates an index for filtering tags and retrieving distinct tag keys.
+func (m *migration_1_2_16) Up(from migrate.Version) error {
+	ctx := context.Background()
+	idxReleases := m.client.
+		Database(m.db).
+		Collection(CollectionReleases).
+		Indexes()
+
+	_, err := idxReleases.CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{
+			Key:   StorageKeyReleaseTags,
+			Value: 1,
+		}, {
+			// Sort by modified date by default when querying by tags
+			Key:   StorageKeyReleaseModified,
+			Value: -1,
+		}},
+		Options: mopts.Index().
+			SetName(IndexNameReleaseTags),
+	})
+	if err != nil {
+		return fmt.Errorf("mongo(1.2.16): failed to create index: %w", err)
+	}
+	return nil
+}
+
+func (m *migration_1_2_16) Version() migrate.Version {
+	return migrate.MakeVersion(1, 2, 16)
+}

--- a/store/mongo/migrations.go
+++ b/store/mongo/migrations.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	DbVersion        = "1.2.15"
+	DbVersion        = "1.2.16"
 	DbMinimumVersion = "1.2.14"
 	DbName           = "deployment_service"
 )
@@ -131,6 +131,10 @@ func MigrateSingle(ctx context.Context,
 			db:     db,
 		},
 		&migration_1_2_15{
+			client: client,
+			db:     db,
+		},
+		&migration_1_2_16{
 			client: client,
 			db:     db,
 		},

--- a/store/mongo/migrations_test.go
+++ b/store/mongo/migrations_test.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package mongo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	mgopts "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestMigration_1_2_6(t *testing.T) {
+	ctx := context.Background()
+	client := db.Client()
+
+	t.Run("ok", func(t *testing.T) {
+		migration := &migration_1_2_16{
+			client: client,
+			db:     "deployments_test",
+		}
+		err := migration.Up(migrate.MakeVersion(1, 2, 15))
+		assert.NoError(t, err)
+		assert.Equal(t, migrate.MakeVersion(1, 2, 16), migration.Version())
+	})
+
+	t.Run("error/indexAlreadyExist", func(t *testing.T) {
+		collBadReleases := client.Database("deployments_test_bad").
+			Collection(CollectionReleases)
+		idxView := collBadReleases.Indexes()
+
+		// Create a bad index with the same name
+		_, _ = idxView.CreateOne(ctx, mongo.IndexModel{
+			Keys: bson.D{{
+				Key: "bad", Value: 1,
+			}},
+			Options: mgopts.Index().
+				SetName(IndexNameReleaseTags),
+		})
+
+		migration_fail := &migration_1_2_16{
+			client: client,
+			db:     "deployments_test_bad",
+		}
+		err := migration_fail.Up(migrate.MakeVersion(1, 2, 15))
+		var srvErr mongo.ServerError
+		assert.ErrorAs(t, err, &srvErr)
+	})
+}


### PR DESCRIPTION
:memo: Reshaped the model from #871 to use string tags.

This PR adds support for tagging and listing all tags for releases.
NOTE: There are two deviations from the original tasks acceptance criteria:
 * Tags are only associated with `Release`s and not `Artifact`s - therefore tags are explicitly put on releases.
 * Two tag limits are implemented to prevent abuse: Max 20 tags per releases and max 100 unique tags across releases.
   * Staying within these limits will also constraint the UX to the desired behavior.