### PR TITLE
docs: Document and improve message for 409 on artifact uploads

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -715,8 +715,16 @@ func (d *DeploymentsApiHandlers) newImageWithContext(
 		d.view.RenderSuccessPost(w, r, imgID)
 		return
 	}
-	if cErr, ok := err.(*model.ConflictError); ok {
-		d.view.RenderError(w, r, cErr, http.StatusConflict, l)
+	var cErr *model.ConflictError
+	if errors.As(err, &cErr) {
+		w.WriteHeader(http.StatusConflict)
+		_ = cErr.WithRequestID(requestid.FromContext(ctx))
+		err = w.WriteJson(cErr)
+		if err != nil {
+			l.Error(err)
+		} else {
+			l.Error(cErr.Error())
+		}
 		return
 	}
 	cause := errors.Cause(err)

--- a/api/http/images_test.go
+++ b/api/http/images_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -41,11 +41,10 @@ import (
 
 func TestPostArtifacts(t *testing.T) {
 	var testConflictError = model.NewConflictError(
-		store_mongo.ErrMsgConflictingDepends,
-		`{meta_artifact.artifact_name: "foobar", `+
-			`meta_artifact.depends_idx: {`+
-			`"device_type": "arm6", "checksum": "2"}}`,
-	)
+		store_mongo.ErrConflictingDepends,
+	).WithMetadata(map[string]interface{}{
+		"conflict": map[string]interface{}{"device_type": "arm6"},
+	})
 
 	imageBody := []byte("123456790")
 
@@ -159,7 +158,7 @@ func TestPostArtifacts(t *testing.T) {
 			responseCode:       http.StatusConflict,
 			// no slashes will be present in the real response - must be added
 			// because we're comparing to body, _ := recorded.DecodedBody(), which does does funny formatting
-			responseBody:           store_mongo.ErrMsgConflictingDepends,
+			responseBody:           store_mongo.ErrConflictingDepends.Error(),
 			appCreateImage:         true,
 			appCreateImageResponse: "24436884-a710-4d20-aec4-82c89fbfe29e",
 			appCreateImageError:    testConflictError,
@@ -214,11 +213,10 @@ func TestPostArtifacts(t *testing.T) {
 func TestPostArtifactsInternal(t *testing.T) {
 	imageBody := []byte("123456790")
 	var testConflictError = model.NewConflictError(
-		store_mongo.ErrMsgConflictingDepends,
-		`{meta_artifact.artifact_name: "foobar", `+
-			`meta_artifact.depends_idx: {`+
-			`"device_type": "arm6", "checksum": "2"}}`,
-	)
+		store_mongo.ErrConflictingDepends,
+	).WithMetadata(map[string]interface{}{
+		"conflict": map[string]interface{}{"device_type": "arm6"},
+	})
 
 	testCases := []struct {
 		requestBodyObject      []h.Part
@@ -330,7 +328,7 @@ func TestPostArtifactsInternal(t *testing.T) {
 			responseCode:       http.StatusConflict,
 			// no slashes will be present in the real response - must be added
 			// because we're comparing to body, _ := recorded.DecodedBody(), which does does funny formatting
-			responseBody:           store_mongo.ErrMsgConflictingDepends,
+			responseBody:           store_mongo.ErrConflictingDepends.Error(),
 			appCreateImage:         true,
 			appCreateImageResponse: "24436884-a710-4d20-aec4-82c89fbfe29e",
 			appCreateImageError:    testConflictError,

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -1105,6 +1105,18 @@ paths:
           $ref: "#/responses/InvalidRequestError"
         401:
           $ref: '#/responses/UnauthorizedError'
+        409:
+          description: |
+            An artifact with the same name and matching dependency requirements already exists.
+          schema:
+            $ref: "#/definitions/ErrorExt"
+          examples:
+            application/json:
+              error: "an artifact with the same name and depends already exists"
+              request_id: "e4dde7e9-9424-4311-8648-86e24b542410"
+              metadata:
+                conflict:
+                  want: cookies
         500:
           $ref: "#/responses/InternalServerError"
 
@@ -1514,6 +1526,26 @@ definitions:
     example:
       error: "failed to decode request body: JSON payload is empty"
       request_id: "f7881e82-0492-49fb-b459-795654e7188a"
+    required: [error]
+  ErrorExt:
+    description: Error descriptor with additional metadata.
+    type: object
+    properties:
+      error:
+        description: Description of the error.
+        type: string
+      request_id:
+        description: Request ID (same as in X-MEN-RequestID header).
+        type: string
+      metadata:
+        type: object
+        additionalProperties: true
+    required: [error]
+    example:
+      error: "error description"
+      request_id: "11de4197-d8cf-4bd2-8a3a-29f88f238e7b"
+      metadata:
+        additional: properties
   NewDeployment:
     type: object
     properties:


### PR DESCRIPTION
Properly parses the server error from MongoDB and adds the conflicting dependency to the error response `metadata` attribute.