### PR TITLE
fix: Delete device deployment history incorrectly triggering reindex

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1969,7 +1969,10 @@ func (d *Deployments) DeleteDeviceDeploymentsHistory(ctx context.Context, device
 		deviceDeployments[i].DeviceID = d.DeviceId
 		deviceDeployments[i].DeploymentID = d.DeploymentId
 	}
-	return d.workflowsClient.StartReindexReportingDeploymentBatch(ctx, deviceDeployments)
+	if d.reportingClient != nil {
+		err = d.workflowsClient.StartReindexReportingDeploymentBatch(ctx, deviceDeployments)
+	}
+	return err
 }
 
 // Storage settings

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1278,11 +1278,14 @@ func TestDeleteDeviceDeploymentsHistory(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(fmt.Sprintf("test case %s", name), func(t *testing.T) {
 
+			rc := new(reporting_mocks.Client)
+			defer rc.AssertExpectations(t)
 			defer tc.workflowsMock.AssertExpectations(t)
 			defer tc.storeMock.AssertExpectations(t)
 			ds := &Deployments{
 				db:              tc.storeMock,
 				workflowsClient: tc.workflowsMock,
+				reportingClient: rc,
 			}
 
 			err := ds.DeleteDeviceDeploymentsHistory(ctx, deviceID)


### PR DESCRIPTION
The endpoint was missing the reporting feature flag check, which caused it to send reindexing request even though the reporting service is disabled.

Changelog: Commit
Ticket: MEN-6614
Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>
(cherry picked from commit fa7e4d762e3a9d9fc315f0237e767f8c3eb23b0b)