### PR TITLE
chore: back-porting helper function and parameters to NewDeployments

### DIFF
--- a/api/http/releases_test.go
+++ b/api/http/releases_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ func TestGetReleases(t *testing.T) {
 			fileStorage := &fs_mocks.ObjectStorage{}
 
 			restView := new(view.RESTView)
-			app := app.NewDeployments(store, fileStorage)
+			app := app.NewDeployments(store, fileStorage, 0, false)
 
 			c := NewDeploymentsApiHandlers(store, restView, app)
 
@@ -235,7 +235,7 @@ func TestListReleases(t *testing.T) {
 			fileStorage := &fs_mocks.ObjectStorage{}
 
 			restView := new(view.RESTView)
-			app := app.NewDeployments(store, fileStorage)
+			app := app.NewDeployments(store, fileStorage, 0, false)
 
 			c := NewDeploymentsApiHandlers(store, restView, app)
 

--- a/app/app_cmd_test.go
+++ b/app/app_cmd_test.go
@@ -154,7 +154,7 @@ func TestCleanupExpiredUploads(t *testing.T) {
 			}
 		}
 
-		app := NewDeployments(database, objectStore)
+		app := NewDeployments(database, objectStore, 0, false)
 
 		err := app.CleanupExpiredUploads(ctx, 0, jitter)
 		assert.NoError(t, err)
@@ -181,7 +181,7 @@ func TestCleanupExpiredUploads(t *testing.T) {
 			Return(iterator, nil).
 			Once()
 
-		app := NewDeployments(database, objectStore)
+		app := NewDeployments(database, objectStore, 0, false)
 
 		go func() {
 			select {
@@ -232,7 +232,7 @@ func TestCleanupExpiredUploads(t *testing.T) {
 				Once()
 		}
 
-		app := NewDeployments(database, objectStore)
+		app := NewDeployments(database, objectStore, 0, false)
 
 		err := app.CleanupExpiredUploads(ctx, 0, jitter)
 		assert.ErrorIs(t, err, errInternal)
@@ -256,7 +256,7 @@ func TestCleanupExpiredUploads(t *testing.T) {
 			Return(nil, errInternal).
 			Once()
 
-		app := NewDeployments(database, objectStore)
+		app := NewDeployments(database, objectStore, 0, false)
 
 		err := app.CleanupExpiredUploads(ctx, 0, jitter)
 		assert.ErrorIs(t, err, errInternal)

--- a/app/app_releases_test.go
+++ b/app/app_releases_test.go
@@ -104,7 +104,7 @@ func TestReplaceReleaseTags(t *testing.T) {
 			ds := tc.GetDatabase(t, &tc)
 			defer ds.AssertExpectations(t)
 
-			app := NewDeployments(ds, nil)
+			app := NewDeployments(ds, nil, 0, false)
 
 			err := app.ReplaceReleaseTags(tc.Context, tc.ReleaseName, tc.Tags)
 			if tc.Error != nil {
@@ -162,7 +162,7 @@ func TestListReleaseTags(t *testing.T) {
 			ds := tc.GetDatabase(t, &tc)
 			defer ds.AssertExpectations(t)
 
-			app := NewDeployments(ds, nil)
+			app := NewDeployments(ds, nil, 0, false)
 
 			tags, err := app.ListReleaseTags(tc.Context)
 			if tc.Error != nil {
@@ -221,7 +221,7 @@ func TestGetReleasesUpdateTypes(t *testing.T) {
 			ds := tc.GetDatabase(t, &tc)
 			defer ds.AssertExpectations(t)
 
-			app := NewDeployments(ds, nil)
+			app := NewDeployments(ds, nil, 0, false)
 
 			tags, err := app.GetReleasesUpdateTypes(tc.Context)
 			if tc.Error != nil {
@@ -302,7 +302,7 @@ func TestUpdateRelease(t *testing.T) {
 			ds := tc.GetDatabase(t, &tc)
 			defer ds.AssertExpectations(t)
 
-			app := NewDeployments(ds, nil)
+			app := NewDeployments(ds, nil, 0, false)
 
 			err := app.UpdateRelease(tc.Context, tc.ReleaseName, tc.Release)
 			if tc.Error != nil {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -315,7 +315,7 @@ func TestDeploymentModelCreateDeployment(t *testing.T) {
 					testCase.InputImagesByNameError)
 
 			fs := &fs_mocks.ObjectStorage{}
-			ds := NewDeployments(&db, fs)
+			ds := NewDeployments(&db, fs, 0, false)
 
 			mockInventoryClient := &inventory_mocks.Client{}
 			if testCase.CallGetDeviceGroups {
@@ -442,7 +442,7 @@ func TestUploadLink(t *testing.T) {
 		ctx := context.Background()
 		objStore := new(fs_mocks.ObjectStorage)
 		ds := new(mocks.DataStore)
-		deploy := NewDeployments(ds, objStore)
+		deploy := NewDeployments(ds, objStore, 0, false)
 		objStore.On("PutRequest",
 			h.ContextMatcher(),
 			regexMatcher(`^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\`+
@@ -469,7 +469,7 @@ func TestUploadLink(t *testing.T) {
 		})
 		objStore := new(fs_mocks.ObjectStorage)
 		ds := new(mocks.DataStore)
-		deploy := NewDeployments(ds, objStore)
+		deploy := NewDeployments(ds, objStore, 0, false)
 		objStore.On("PutRequest",
 			h.ContextMatcher(),
 			regexMatcher(`^123456789012345678901234/`+
@@ -497,7 +497,7 @@ func TestUploadLink(t *testing.T) {
 		})
 		objStore := new(fs_mocks.ObjectStorage)
 		ds := new(mocks.DataStore)
-		deploy := NewDeployments(ds, objStore)
+		deploy := NewDeployments(ds, objStore, 0, false)
 		errInternal := errors.New("internal error")
 		ds.On("GetStorageSettings", ctx).
 			Return(nil, nil).
@@ -523,7 +523,7 @@ func TestUploadLink(t *testing.T) {
 		})
 		objStore := new(fs_mocks.ObjectStorage)
 		ds := new(mocks.DataStore)
-		deploy := NewDeployments(ds, objStore)
+		deploy := NewDeployments(ds, objStore, 0, false)
 		errInternal := errors.New("internal error")
 		objStore.On("PutRequest",
 			h.ContextMatcher(),
@@ -551,7 +551,7 @@ func TestUploadLink(t *testing.T) {
 		})
 		objStore := new(fs_mocks.ObjectStorage)
 		ds := new(mocks.DataStore)
-		deploy := NewDeployments(ds, objStore)
+		deploy := NewDeployments(ds, objStore, 0, false)
 		errInternal := errors.New("internal error")
 		ds.On("GetStorageSettings", ctx).
 			Return(nil, errInternal).
@@ -991,7 +991,7 @@ func TestCompleteUpload(t *testing.T) {
 			defer ds.AssertExpectations(t)
 			objStore := tc.ObjectStorage(t, tc)
 			defer objStore.AssertExpectations(t)
-			deploy := NewDeployments(ds, objStore)
+			deploy := NewDeployments(ds, objStore, 0, false)
 
 			err := deploy.CompleteUpload(ctx, intentID, tc.SkipVerify)
 			tc.ErrorAssertionFunc(t, tc, err)

--- a/app/images_test.go
+++ b/app/images_test.go
@@ -44,7 +44,7 @@ func (r *BogusReader) Read(b []byte) (int, error) {
 func TestGenerateImageError(t *testing.T) {
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 
 	testCases := []struct {
 		multipartGenerateImage *model.MultipartGenerateImageMsg
@@ -72,7 +72,7 @@ func TestGenerateImageError(t *testing.T) {
 func TestGenerateImageArtifactIsNotUnique(t *testing.T) {
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 
 	db.On("IsArtifactUnique",
 		h.ContextMatcher(),
@@ -102,7 +102,7 @@ func TestGenerateImageArtifactIsNotUnique(t *testing.T) {
 func TestGenerateImageErrorWhileCheckingIfArtifactIsNotUnique(t *testing.T) {
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 
 	db.On("IsArtifactUnique",
 		h.ContextMatcher(),
@@ -132,7 +132,7 @@ func TestGenerateImageErrorWhileCheckingIfArtifactIsNotUnique(t *testing.T) {
 func TestGenerateImageErrorWhileUploading(t *testing.T) {
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 	ctx := context.Background()
 
 	fs.On("PutObject",
@@ -173,7 +173,7 @@ func TestGenerateImageErrorWhileUploading(t *testing.T) {
 func TestGenerateImageErrorS3GetRequest(t *testing.T) {
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 	ctx := context.Background()
 
 	fs.On("PutObject",
@@ -225,7 +225,7 @@ func TestGenerateImageErrorS3GetRequest(t *testing.T) {
 func TestGenerateImageErrorS3DeleteRequest(t *testing.T) {
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 	ctx := context.Background()
 
 	fs.On("PutObject",
@@ -286,7 +286,7 @@ func TestGenerateImageErrorWhileStartingWorkflow(t *testing.T) {
 	generateErr := errors.New("failed to start workflow: generate_artifact")
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 	ctx := context.Background()
 
 	fs.On("GetRequest",
@@ -358,7 +358,7 @@ func TestGenerateImageErrorWhileStartingWorkflow(t *testing.T) {
 func TestGenerateImageErrorWhileStartingWorkflowAndFailsWhenCleaningUp(t *testing.T) {
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 	ctx := context.Background()
 
 	workflowsClient := &workflows_mocks.Client{}
@@ -432,7 +432,7 @@ func TestGenerateImageSuccessful(t *testing.T) {
 	ctx := context.Background()
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 
 	multipartGenerateImage := &model.MultipartGenerateImageMsg{
 		Name:                  "name",
@@ -499,7 +499,7 @@ func TestGenerateImageSuccessfulWithTenant(t *testing.T) {
 	ctx := context.Background()
 	db := mocks.DataStore{}
 	fs := &fs_mocks.ObjectStorage{}
-	d := NewDeployments(&db, fs)
+	d := NewDeployments(&db, fs, 0, false)
 
 	multipartGenerateImage := &model.MultipartGenerateImageMsg{
 		Name:                  "name",
@@ -648,7 +648,7 @@ func TestGenerateConfigurationImage(t *testing.T) {
 			defer ds.AssertExpectations(t)
 			ds.On("FindDeploymentByID", ctx, tc.DeploymentID).
 				Return(tc.Deployment, tc.StoreError)
-			d := NewDeployments(ds, nil)
+			d := NewDeployments(ds, nil, 0, false)
 			artieFact, err := d.GenerateConfigurationImage(
 				ctx, tc.DeviceType, tc.DeploymentID,
 			)

--- a/app/limits_test.go
+++ b/app/limits_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ func TestGetLimit(t *testing.T) {
 
 			fs := &fs_mocks.ObjectStorage{}
 
-			d := NewDeployments(&db, fs)
+			d := NewDeployments(&db, fs, 0, false)
 
 			ctx := context.Background()
 			lim, err := d.GetLimit(ctx, tc.name)

--- a/app/status_test.go
+++ b/app/status_test.go
@@ -89,7 +89,7 @@ func TestUpdateDeviceDeploymentStatus(t *testing.T) {
 		model.DeploymentStatusInProgress,
 		mock.AnythingOfType("time.Time")).Return(nil).Once()
 
-	ds := NewDeployments(&db, fs)
+	ds := NewDeployments(&db, fs, 0, false)
 
 	err = ds.UpdateDeviceDeploymentStatus(ctx, fakeDeployment.Id, fakeDeviceDeployment.DeviceId, ddStatusNew)
 	assert.NoError(t, err)
@@ -200,7 +200,7 @@ func TestGetDeploymentForDeviceWithCurrent(t *testing.T) {
 		mock.AnythingOfType("model.DeviceDeployment"),
 	).Return(nil)
 
-	ds := NewDeployments(&db, fs)
+	ds := NewDeployments(&db, fs, 0, false)
 
 	_, err = ds.GetDeploymentForDeviceWithCurrent(ctx, devId, request)
 	assert.NoError(t, err)
@@ -381,7 +381,7 @@ func TestDecommissionDevice(t *testing.T) {
 				mock.AnythingOfType("model.DeviceDeployment"),
 			).Return(nil)
 
-			ds := NewDeployments(&db, nil)
+			ds := NewDeployments(&db, nil, 0, false)
 
 			err := ds.DecommissionDevice(ctx, tc.inputDeviceId)
 			if tc.outputError != nil {
@@ -580,7 +580,7 @@ func TestAbortDeviceDeployments(t *testing.T) {
 				mock.AnythingOfType("model.DeviceDeployment"),
 			).Return(nil)
 
-			ds := NewDeployments(&db, nil)
+			ds := NewDeployments(&db, nil, 0, false)
 
 			err := ds.AbortDeviceDeployments(ctx, tc.inputDeviceId)
 			if tc.outputError != nil {

--- a/app/tenants_test.go
+++ b/app/tenants_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ func TestProvisionTenant(t *testing.T) {
 
 			fs := &fs_mocks.ObjectStorage{}
 
-			d := NewDeployments(&db, fs)
+			d := NewDeployments(&db, fs, 0, false)
 
 			ctx := context.Background()
 

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func cmdStorageDaemon(args *cli.Context) error {
 		return err
 	}
 	database := mongo.NewDataStoreMongoWithClient(mgo)
-	app := app.NewDeployments(database, objectStorage)
+	app := app.NewDeployments(database, objectStorage, 0, false)
 	return app.CleanupExpiredUploads(
 		ctx,
 		args.Duration("interval"),

--- a/server.go
+++ b/server.go
@@ -175,7 +175,7 @@ func RunServer(ctx context.Context) error {
 		return errors.WithMessage(err, "main: failed to setup storage client")
 	}
 
-	app := app.NewDeployments(ds, objStore)
+	app := app.NewDeployments(ds, objStore, 0, false)
 	if addr := c.GetString(dconfig.SettingReportingAddr); addr != "" {
 		c := reporting.NewClient(addr)
 		app = app.WithReporting(c)


### PR DESCRIPTION
two backports in order to reduce number of conflicts:

* while bringing changes to ent fork extra function was needed, due to the fact that handleArtifact crossed the QA-required complexity of (20). back porting saveUpdateTypes to reduce the number of conflicts in the future os->ent syncs

* the ent-os discrepancy of NewDeployments arguments is something that is a conflicts producer and waste of time: you always have to fix the units on the way from os to ent.

Ticket: None