### PR TITLE
feat: Optimize finding newer active deployments for device using MongoDB Aggregation

### DIFF
--- a/store/datastore.go
+++ b/store/datastore.go
@@ -197,6 +197,7 @@ type DataStore interface {
 	ListReleaseTags(ctx context.Context) (model.Tags, error)
 	SaveUpdateTypes(ctx context.Context, updateTypes []string) error
 	GetUpdateTypes(ctx context.Context) ([]string, error)
+	FindOldestActiveDeploymentForDevice(ctx context.Context, deviceID string, createdAfter *time.Time) (*model.Deployment, error)
 }
 
 var ErrNotFound = errors.New("document not found")


### PR DESCRIPTION
Optimize finding newer active deployments for device using MongoDB aggregation

Noticed a lot of data egress when a device checks for an update, especially if the deployment size is large.

This commit optimizes a database query using the MongoDB aggregation framework to improve performance and reduce resource usage and network data transfer. The changes include a more efficient aggregation pipeline to fetch data, resulting in faster query execution and less data transferred overall.

Changelog: All
Ticket: None