### PR TITLE
fix: db.Find: look for phrases (escape the $text elements)

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -2617,7 +2617,7 @@ func (db *DataStoreMongo) Find(ctx context.Context,
 
 		tq := bson.M{
 			"$text": bson.M{
-				"$search": match.SearchText,
+				"$search": "\"" + match.SearchText + "\"",
 			},
 		}
 

--- a/store/mongo/deployments_external_test.go
+++ b/store/mongo/deployments_external_test.go
@@ -1286,14 +1286,11 @@ func TestDeploymentStorageFindBy(t *testing.T) {
 		},
 		{
 			InputModelQuery: model.Query{
-				SearchText: "NYC foo",
+				SearchText: "NYC Production Inc.",
 			},
 			InputDeploymentsCollection: someDeployments,
 			OutputError:                nil,
 			OutputID: []string{
-				"a108ae14-bb4e-455f-9b40-000000000005",
-				"a108ae14-bb4e-455f-9b40-000000000004",
-				"a108ae14-bb4e-455f-9b40-000000000003",
 				"a108ae14-bb4e-455f-9b40-000000000002",
 				"a108ae14-bb4e-455f-9b40-000000000001",
 			},


### PR DESCRIPTION
We have to escape the $text search to look for a phrase, otherwise there are special characters, and individual terms searching in place.

Changelog: Title
Ticket: MEN-6730