### PR TITLE
fix release filtering and RBAC for releases

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -775,7 +775,7 @@ func (db *DataStoreMongo) getReleases_1_2_15(
 			}}
 		}
 		if len(filt.Tags) > 0 {
-			filter[StorageKeyReleaseTags] = bson.M{"$all": filt.Tags}
+			filter[StorageKeyReleaseTags] = bson.M{"$in": filt.Tags}
 		}
 		if filt.Description != "" {
 			filter[StorageKeyReleaseArtifactsDescription] = bson.M{"$regex": primitive.Regex{

--- a/store/mongo/datastore_mongo_releases_test.go
+++ b/store/mongo/datastore_mongo_releases_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Northern.tech AS
+// Copyright 2024 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -510,6 +510,31 @@ func TestGetReleases_1_2_15(t *testing.T) {
 					},
 					ArtifactsCount: 2,
 					Tags:           releaseNameToTags["App2 v0.1"],
+				},
+			},
+		},
+		"ok, tags": {
+			releaseFilt: &model.ReleaseOrImageFilter{
+				Tags: []string{"production", "demo"},
+			},
+			releases: []model.Release{
+				{
+					Name: "App1 v1.0",
+					Artifacts: []model.Image{
+						*inputImgs[0],
+						*inputImgs[2],
+						*inputImgs[3],
+					},
+					ArtifactsCount: 3,
+					Tags:           releaseNameToTags["App1 v1.0"],
+				},
+				{
+					Name: "App4 v2.0",
+					Artifacts: []model.Image{
+						*inputImgs[5],
+					},
+					ArtifactsCount: 1,
+					Tags:           releaseNameToTags["App4 v2.0"],
 				},
 			},
 		},


### PR DESCRIPTION
With the old implementation, when using more than one tag in the filter, or when using role which grants access to releases with given tag (and more than one tag was specified), deployments will present only releases containg ALL the tags each.
With the new behavior, deployments will retrun all the releases containg ANY of the tags.

Ticket: MEN-7272