### PR TITLE
perf: Optimize database interactions when updating deployment stats

### DIFF
--- a/app/app_os.go
+++ b/app/app_os.go
@@ -46,10 +46,9 @@ func (d *Deployments) handleAlreadyInstalled(
 	deviceDeployment *model.DeviceDeployment,
 ) error {
 	l := log.FromContext(ctx)
-	if err := d.UpdateDeviceDeploymentStatus(
+	if err := d.updateDeviceDeploymentStatus(
 		ctx,
-		deviceDeployment.DeploymentId,
-		deviceDeployment.DeviceId,
+		deviceDeployment,
 		model.DeviceDeploymentState{
 			Status: model.DeviceDeploymentStatusAlreadyInst,
 		}); err != nil {
@@ -137,8 +136,7 @@ func (d *Deployments) assignNoArtifact(
 	deviceDeployment *model.DeviceDeployment,
 ) error {
 	l := log.FromContext(ctx)
-	if err := d.UpdateDeviceDeploymentStatus(ctx, deviceDeployment.DeploymentId,
-		deviceDeployment.DeviceId,
+	if err := d.updateDeviceDeploymentStatus(ctx, deviceDeployment,
 		model.DeviceDeploymentState{
 			Status: model.DeviceDeploymentStatusNoArtifact,
 		}); err != nil {

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -147,7 +147,7 @@ type DataStore interface {
 		id string,
 		stateFrom,
 		stateTo model.DeviceDeploymentStatus,
-	) error
+	) (model.Stats, error)
 	UpdateStats(ctx context.Context,
 		id string, stats model.Stats) error
 	Find(ctx context.Context,

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -1294,7 +1294,7 @@ func (_m *DataStore) UpdateDeviceDeploymentLogAvailability(ctx context.Context, 
 	return r0
 }
 
-// UpdateDeviceDeploymentStatus provides a mock function with given fields: ctx, deviceID, deploymentID, state
+// UpdateDeviceDeploymentStatus provides a mock function with given fields: ctx, deviceID, deploymentID, state, currentStatus
 func (_m *DataStore) UpdateDeviceDeploymentStatus(ctx context.Context, deviceID string, deploymentID string, state model.DeviceDeploymentState, currentStatus model.DeviceDeploymentStatus) (model.DeviceDeploymentStatus, error) {
 	ret := _m.Called(ctx, deviceID, deploymentID, state, currentStatus)
 
@@ -1372,17 +1372,26 @@ func (_m *DataStore) UpdateStats(ctx context.Context, id string, stats model.Sta
 }
 
 // UpdateStatsInc provides a mock function with given fields: ctx, id, stateFrom, stateTo
-func (_m *DataStore) UpdateStatsInc(ctx context.Context, id string, stateFrom model.DeviceDeploymentStatus, stateTo model.DeviceDeploymentStatus) error {
+func (_m *DataStore) UpdateStatsInc(ctx context.Context, id string, stateFrom model.DeviceDeploymentStatus, stateTo model.DeviceDeploymentStatus) (model.Stats, error) {
 	ret := _m.Called(ctx, id, stateFrom, stateTo)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, model.DeviceDeploymentStatus, model.DeviceDeploymentStatus) error); ok {
+	var r0 model.Stats
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.DeviceDeploymentStatus, model.DeviceDeploymentStatus) model.Stats); ok {
 		r0 = rf(ctx, id, stateFrom, stateTo)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(model.Stats)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, model.DeviceDeploymentStatus, model.DeviceDeploymentStatus) error); ok {
+		r1 = rf(ctx, id, stateFrom, stateTo)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UpdateUploadIntentStatus provides a mock function with given fields: ctx, id, from, to

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -187,37 +187,6 @@ var (
 		Options: mopts.Index().
 			SetName(IndexDeviceDeploymentStatusName),
 	}
-	DeploymentStatusFinishedIndex = mongo.IndexModel{
-		Keys: bson.D{
-			{Key: "stats.downloading", Value: 1},
-			{Key: "stats.installing", Value: 1},
-			{Key: "stats.pending", Value: 1},
-			{Key: "stats.rebooting", Value: 1},
-			{Key: "created", Value: -1},
-		},
-		Options: &mopts.IndexOptions{
-			Background: &_false,
-			Name:       &IndexDeploymentStatusFinishedName,
-		},
-	}
-	DeploymentStatusPendingIndex = mongo.IndexModel{
-		Keys: bson.D{
-			{Key: "stats.aborted", Value: 1},
-			{Key: "stats.already-installed", Value: 1},
-			{Key: "stats.decommissioned", Value: 1},
-			{Key: "stats.downloading", Value: 1},
-			{Key: "stats.failure", Value: 1},
-			{Key: "stats.installing", Value: 1},
-			{Key: "stats.noartifact", Value: 1},
-			{Key: "stats.rebooting", Value: 1},
-			{Key: "stats.success", Value: 1},
-			{Key: "created", Value: -1},
-		},
-		Options: &mopts.IndexOptions{
-			Background: &_false,
-			Name:       &IndexDeploymentStatusPendingName,
-		},
-	}
 	DeploymentCreatedIndex = mongo.IndexModel{
 		Keys: bson.D{
 			{Key: "created", Value: -1},
@@ -225,33 +194,6 @@ var (
 		Options: &mopts.IndexOptions{
 			Background: &_false,
 			Name:       &IndexDeploymentCreatedName,
-		},
-	}
-	DeploymentDeviceStatusRebootingIndex = mongo.IndexModel{
-		Keys: bson.D{
-			{Key: "stats.rebooting", Value: 1},
-		},
-		Options: &mopts.IndexOptions{
-			Background: &_false,
-			Name:       &IndexDeploymentDeviceStatusRebootingName,
-		},
-	}
-	DeploymentDeviceStatusPendingIndex = mongo.IndexModel{
-		Keys: bson.D{
-			{Key: "stats.pending", Value: 1},
-		},
-		Options: &mopts.IndexOptions{
-			Background: &_false,
-			Name:       &IndexDeploymentDeviceStatusPendingName,
-		},
-	}
-	DeploymentDeviceStatusInstallingIndex = mongo.IndexModel{
-		Keys: bson.D{
-			{Key: "stats.installing", Value: 1},
-		},
-		Options: &mopts.IndexOptions{
-			Background: &_false,
-			Name:       &IndexDeploymentDeviceStatusInstallingName,
 		},
 	}
 	DeploymentDeviceStatusFinishedIndex = mongo.IndexModel{

--- a/store/mongo/deployments_external_test.go
+++ b/store/mongo/deployments_external_test.go
@@ -785,17 +785,7 @@ func TestDeploymentStorageUpdateStatsInc(t *testing.T) {
 			InputStateTo:   model.DeviceDeploymentStatusInstalling,
 
 			OutputError: nil,
-			OutputStats: model.Stats{
-				model.DeviceDeploymentStatusDownloadingStr: 1,
-				model.DeviceDeploymentStatusInstallingStr:  2,
-				model.DeviceDeploymentStatusRebootingStr:   3,
-				model.DeviceDeploymentStatusPendingStr:     10,
-				model.DeviceDeploymentStatusSuccessStr:     15,
-				model.DeviceDeploymentStatusFailureStr:     4,
-				model.DeviceDeploymentStatusNoArtifactStr:  5,
-				model.DeviceDeploymentStatusAlreadyInstStr: 0,
-				model.DeviceDeploymentStatusAbortedStr:     0,
-			},
+			OutputStats: nil,
 		},
 		"tenant, pending -> finished": {
 			InputID: "a108ae14-bb4e-455f-9b40-2ef4bab97bb7",
@@ -871,21 +861,13 @@ func TestDeploymentStorageUpdateStatsInc(t *testing.T) {
 				}
 			}
 
-			err := store.UpdateStatsInc(ctx,
+			stats, err := store.UpdateStatsInc(ctx,
 				tc.InputID, tc.InputStateFrom, tc.InputStateTo)
 
 			if tc.OutputError != nil {
 				assert.EqualError(t, err, tc.OutputError.Error())
 			} else {
-				var deployment *model.Deployment
-				collDep := client.Database(ctxstore.
-					DbFromContext(ctx, DatabaseName)).
-					Collection(CollectionDeployments)
-				err := collDep.FindOne(ctx,
-					bson.M{"_id": tc.InputID}).
-					Decode(&deployment)
-				assert.NoError(t, err)
-				assert.Equal(t, tc.OutputStats, deployment.Stats)
+				assert.Equal(t, tc.OutputStats, stats)
 
 				// if there's a tenant, verify that deployment
 				// in default DB remains unchanged, again only

--- a/store/mongo/migration_1_2_2.go
+++ b/store/mongo/migration_1_2_2.go
@@ -38,12 +38,7 @@ func (m *migration_1_2_2) Up(from migrate.Version) error {
 		return err
 	}
 	return storage.EnsureIndexes(m.db, CollectionDeployments,
-		DeploymentStatusFinishedIndex,
-		DeploymentStatusPendingIndex,
 		DeploymentCreatedIndex,
-		DeploymentDeviceStatusRebootingIndex,
-		DeploymentDeviceStatusPendingIndex,
-		DeploymentDeviceStatusInstallingIndex,
 		DeploymentDeviceStatusFinishedIndex)
 
 }

--- a/store/mongo/migration_1_2_2_test.go
+++ b/store/mongo/migration_1_2_2_test.go
@@ -100,12 +100,7 @@ func TestMigration_1_2_2(t *testing.T) {
 		}
 
 		deploymentsCollectionIndicesNames := []string{
-			IndexDeploymentStatusFinishedName,
-			IndexDeploymentStatusPendingName,
 			IndexDeploymentCreatedName,
-			IndexDeploymentDeviceStatusRebootingName,
-			IndexDeploymentDeviceStatusPendingName,
-			IndexDeploymentDeviceStatusInstallingName,
 			IndexDeploymentDeviceStatusFinishedName,
 		}
 		// verify new deployment indices present


### PR DESCRIPTION
Changed the sequential find and double update ops with a findAndModify followed by a conditional update if the status actually changed. This also improves atomicity as there is an inherent race condition when doing the deployment status aggregation locally.

I also noticed that most internal calls to UpdateDeviceDeploymentStatus already has the DeviceDeployment already, so I added an internal updateDeviceDeploymentStatus which skips fetching the device deployment (again).