### PR TITLE
feat: enable exact artifact name, description, and device type matching in list artifacts requests

### DIFF
--- a/api/http/api_deployments.go
+++ b/api/http/api_deployments.go
@@ -71,19 +71,22 @@ const (
 // storage keys
 const (
 	// Common HTTP form parameters
-	ParamArtifactName = "artifact_name"
-	ParamDeviceType   = "device_type"
-	ParamUpdateType   = "update_type"
-	ParamDeploymentID = "deployment_id"
-	ParamDeviceID     = "device_id"
-	ParamTenantID     = "tenant_id"
-	ParamName         = "name"
-	ParamTag          = "tag"
-	ParamDescription  = "description"
-	ParamPage         = "page"
-	ParamPerPage      = "per_page"
-	ParamSort         = "sort"
-	ParamID           = "id"
+	ParamArtifactName     = "artifact_name"
+	ParamDeviceType       = "device_type"
+	ParamUpdateType       = "update_type"
+	ParamDeploymentID     = "deployment_id"
+	ParamDeviceID         = "device_id"
+	ParamTenantID         = "tenant_id"
+	ParamName             = "name"
+	ParamTag              = "tag"
+	ParamDescription      = "description"
+	ParamPage             = "page"
+	ParamPerPage          = "per_page"
+	ParamSort             = "sort"
+	ParamID               = "id"
+	ParamExactName        = "exact_name"
+	ParamExactDescription = "exact_description"
+	ParamExactDeviceType  = "exact_device_type"
 )
 
 const Redacted = "REDACTED"
@@ -280,10 +283,13 @@ func getReleaseOrImageFilter(r *rest.Request, version listReleasesVersion,
 	filter := &model.ReleaseOrImageFilter{
 		Name:       q.Get(ParamName),
 		UpdateType: q.Get(ParamUpdateType),
+		ExactName:  q.Get(ParamExactName) == "true",
 	}
 	if version == listReleasesV1 {
 		filter.Description = q.Get(ParamDescription)
 		filter.DeviceType = q.Get(ParamDeviceType)
+		filter.ExactDescription = q.Get(ParamExactDescription) == "true"
+		filter.ExactDeviceType = q.Get(ParamExactDeviceType) == "true"
 	} else if version == listReleasesV2 {
 		filter.Tags = q[ParamTag]
 		for i, t := range filter.Tags {

--- a/api/http/images_test.go
+++ b/api/http/images_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 
@@ -870,6 +871,78 @@ func TestListImages(t *testing.T) {
 				},
 			),
 		},
+		"ok with exact name": {
+			filter: &dmodel.ReleaseOrImageFilter{
+				Name:      "foo",
+				ExactName: true,
+				Page:      1,
+				PerPage:   20,
+			},
+			images: []*dmodel.Image{
+				{
+					Id:   "1",
+					Size: 1000,
+				},
+			},
+			checker: mt.NewJSONResponse(
+				http.StatusOK,
+				nil,
+				[]*dmodel.Image{
+					{
+						Id:   "1",
+						Size: 1000,
+					},
+				},
+			),
+		},
+		"ok with exact description": {
+			filter: &dmodel.ReleaseOrImageFilter{
+				Description:      "foo",
+				ExactDescription: true,
+				Page:             1,
+				PerPage:          20,
+			},
+			images: []*dmodel.Image{
+				{
+					Id:   "1",
+					Size: 1000,
+				},
+			},
+			checker: mt.NewJSONResponse(
+				http.StatusOK,
+				nil,
+				[]*dmodel.Image{
+					{
+						Id:   "1",
+						Size: 1000,
+					},
+				},
+			),
+		},
+		"ok with exact device type": {
+			filter: &dmodel.ReleaseOrImageFilter{
+				DeviceType:      "raspberrypi4",
+				ExactDeviceType: true,
+				Page:            1,
+				PerPage:         20,
+			},
+			images: []*dmodel.Image{
+				{
+					Id:   "1",
+					Size: 1000,
+				},
+			},
+			checker: mt.NewJSONResponse(
+				http.StatusOK,
+				nil,
+				[]*dmodel.Image{
+					{
+						Id:   "1",
+						Size: 1000,
+					},
+				},
+			),
+		},
 		"ok, empty": {
 			filter: &dmodel.ReleaseOrImageFilter{Page: 1, PerPage: 20},
 			images: []*dmodel.Image{},
@@ -920,17 +993,33 @@ func TestListImages(t *testing.T) {
 			reqUrl := "http://1.2.3.4/api/management/v1/artifacts/list"
 
 			if tc.filter != nil {
-				reqUrl += "?name=" + tc.filter.Name
+				v := url.Values{}
+				if tc.filter.Name != "" {
+					v.Set("name", tc.filter.Name)
+					if tc.filter.ExactName {
+						v.Set("exact_name", "true")
+					}
+				}
+				if tc.filter.Description != "" {
+					v.Set("description", tc.filter.Description)
+					if tc.filter.ExactDescription {
+						v.Set("exact_description", "true")
+					}
+				}
+				if tc.filter.DeviceType != "" {
+					v.Set("device_type", tc.filter.DeviceType)
+					if tc.filter.ExactDeviceType {
+						v.Set("exact_device_type", "true")
+					}
+				}
+				if len(v) > 0 {
+					reqUrl += "?" + v.Encode()
+				}
 			}
 
-			req := test.MakeSimpleRequest("GET",
-				reqUrl,
-				nil)
-
+			req := test.MakeSimpleRequest("GET", reqUrl, nil)
 			req.Header.Add(requestid.RequestIdHeader, "test")
-
 			recorded := test.RunRequest(t, api, req)
-
 			mt.CheckResponse(t, tc.checker, recorded)
 		})
 	}

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -1168,19 +1168,37 @@ paths:
       parameters:
         - name: name
           in: query
-          description: Artifact name filter.
+          description: Artifact name filter (partial match by default).
           required: false
           type: string
         - name: description
           in: query
-          description: Artifact description filter.
+          description: Artifact description filter (partial match by default).
           required: false
           type: string
         - name: device_type
           in: query
-          description: Artifact device type filter.
+          description: Artifact device type filter (partial match by default).
           required: false
           type: string
+        - name: exact_name
+          in: query
+          description: If true, name filter will require exact match instead of partial match.
+          required: false
+          type: boolean
+          default: false
+        - name: exact_description
+          in: query
+          description: If true, description filter will require exact match instead of partial match.
+          required: false
+          type: boolean
+          default: false
+        - name: exact_device_type
+          in: query
+          description: If true, device type filter will require exact match instead of partial match.
+          required: false
+          type: boolean
+          default: false
         - name: page
           in: query
           description: Starting page.

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -628,6 +628,8 @@ definitions:
           $ref: "#/definitions/UpdateFile"
       meta_data:
         type: array
+        items:
+          type: object
         description: |
             meta_data is an array of objects of unknown structure as this
             is dependent of update type (also custom defined by user)

--- a/model/release.go
+++ b/model/release.go
@@ -214,14 +214,17 @@ func (r ReleasePatch) Validate() error {
 }
 
 type ReleaseOrImageFilter struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	DeviceType  string   `json:"device_type"`
-	Tags        []string `json:"tags"`
-	UpdateType  string   `json:"update_type"`
-	Page        int      `json:"page"`
-	PerPage     int      `json:"per_page"`
-	Sort        string   `json:"sort"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	DeviceType       string   `json:"device_type"`
+	ExactName        bool     `json:"exact_name"`
+	ExactDescription bool     `json:"exact_description"`
+	ExactDeviceType  bool     `json:"exact_device_type"`
+	Tags             []string `json:"tags"`
+	UpdateType       string   `json:"update_type"`
+	Page             int      `json:"page"`
+	PerPage          int      `json:"per_page"`
+	Sort             string   `json:"sort"`
 }
 
 type DirectUploadMetadata struct {

--- a/model/release_test.go
+++ b/model/release_test.go
@@ -115,3 +115,107 @@ func TestConvertReleasesToV1(t *testing.T) {
 	releasesV1 := ConvertReleasesToV1(releases)
 	assert.Equal(t, expected, releasesV1)
 }
+
+func TestReleaseOrImageFilter_ExactMatches(t *testing.T) {
+	testCases := []struct {
+		Name         string
+		Filter       ReleaseOrImageFilter
+		ExpectedJSON string
+	}{
+		{
+			Name:   "empty filter",
+			Filter: ReleaseOrImageFilter{},
+			ExpectedJSON: `{
+				"name": "",
+				"description": "",
+				"device_type": "",
+				"exact_name": false,
+				"exact_description": false,
+				"exact_device_type": false,
+				"tags": null,
+				"update_type": "",
+				"page": 0,
+				"per_page": 0,
+				"sort": ""
+			}`,
+		},
+		{
+			Name: "filter with exact matches",
+			Filter: ReleaseOrImageFilter{
+				Name:             "test-release",
+				Description:      "test description",
+				DeviceType:       "raspberrypi4",
+				ExactName:        true,
+				ExactDescription: true,
+				ExactDeviceType:  true,
+				Tags:             []string{"test"},
+				Page:             1,
+				PerPage:          10,
+			},
+			ExpectedJSON: `{
+				"name": "test-release",
+				"description": "test description",
+				"device_type": "raspberrypi4",
+				"exact_name": true,
+				"exact_description": true,
+				"exact_device_type": true,
+				"tags": ["test"],
+				"update_type": "",
+				"page": 1,
+				"per_page": 10,
+				"sort": ""
+			}`,
+		},
+		{
+			Name: "filter with mixed exact and non-exact matches",
+			Filter: ReleaseOrImageFilter{
+				Name:             "test-release",
+				Description:      "test description",
+				DeviceType:       "raspberrypi4",
+				ExactName:        true,
+				ExactDescription: false,
+				ExactDeviceType:  true,
+				Tags:             []string{"test"},
+				Page:             1,
+				PerPage:          10,
+			},
+			ExpectedJSON: `{
+				"name": "test-release",
+				"description": "test description",
+				"device_type": "raspberrypi4",
+				"exact_name": true,
+				"exact_description": false,
+				"exact_device_type": true,
+				"tags": ["test"],
+				"update_type": "",
+				"page": 1,
+				"per_page": 10,
+				"sort": ""
+			}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// Marshal the filter to JSON
+			filterJSON, err := json.Marshal(tc.Filter)
+			assert.NoError(t, err)
+
+			// Create a normalized version of expected and actual JSON for comparison
+			var expected, actual interface{}
+			err = json.Unmarshal([]byte(tc.ExpectedJSON), &expected)
+			assert.NoError(t, err)
+			err = json.Unmarshal(filterJSON, &actual)
+			assert.NoError(t, err)
+
+			// Compare the JSON structures
+			assert.Equal(t, expected, actual)
+
+			// Test unmarshaling back to struct
+			var unmarshaledFilter ReleaseOrImageFilter
+			err = json.Unmarshal(filterJSON, &unmarshaledFilter)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.Filter, unmarshaledFilter)
+		})
+	}
+}

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -1200,30 +1200,41 @@ func (db *DataStoreMongo) ListImages(
 	filters := bson.M{}
 	if filt != nil {
 		if filt.Name != "" {
-			filters[StorageKeyImageName] = bson.M{
-				"$regex": primitive.Regex{
-					Pattern: ".*" + regexp.QuoteMeta(filt.Name) + ".*",
-					Options: "i",
-				},
+			if filt.ExactName {
+				filters[StorageKeyImageName] = filt.Name
+			} else {
+				filters[StorageKeyImageName] = bson.M{
+					"$regex": primitive.Regex{
+						Pattern: ".*" + regexp.QuoteMeta(filt.Name) + ".*",
+						Options: "i",
+					},
+				}
 			}
 		}
 		if filt.Description != "" {
-			filters[StorageKeyImageDescription] = bson.M{
-				"$regex": primitive.Regex{
-					Pattern: ".*" + regexp.QuoteMeta(filt.Description) + ".*",
-					Options: "i",
-				},
+			if filt.ExactDescription {
+				filters[StorageKeyImageDescription] = filt.Description
+			} else {
+				filters[StorageKeyImageDescription] = bson.M{
+					"$regex": primitive.Regex{
+						Pattern: ".*" + regexp.QuoteMeta(filt.Description) + ".*",
+						Options: "i",
+					},
+				}
 			}
 		}
 		if filt.DeviceType != "" {
-			filters[StorageKeyImageDeviceTypes] = bson.M{
-				"$regex": primitive.Regex{
-					Pattern: ".*" + regexp.QuoteMeta(filt.DeviceType) + ".*",
-					Options: "i",
-				},
+			if filt.ExactDeviceType {
+				filters[StorageKeyImageDeviceTypes] = filt.DeviceType
+			} else {
+				filters[StorageKeyImageDeviceTypes] = bson.M{
+					"$regex": primitive.Regex{
+						Pattern: ".*" + regexp.QuoteMeta(filt.DeviceType) + ".*",
+						Options: "i",
+					},
+				}
 			}
 		}
-
 	}
 
 	projection := bson.M{

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -2486,3 +2486,154 @@ func TestGetDeploymentIDsByArtifactNames(t *testing.T) {
 		})
 	}
 }
+
+func TestMongoListImages_ExactMatches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestMongoListImages_ExactMatches in short mode.")
+	}
+
+	testCases := []struct {
+		Name           string
+		InputImages    []interface{}
+		InputFilter    *model.ReleaseOrImageFilter
+		ExpectedCount  int
+		ExpectedImages []string
+	}{
+		{
+			Name: "exact name match",
+			InputImages: []interface{}{
+				model.Image{
+					Id: "1",
+					ImageMeta: &model.ImageMeta{
+						Description: "test description",
+					},
+					ArtifactMeta: &model.ArtifactMeta{
+						Name:                  "test-image",
+						DeviceTypesCompatible: []string{"device1"},
+					},
+				},
+				model.Image{
+					Id: "2",
+					ArtifactMeta: &model.ArtifactMeta{
+						Name:                  "test-image-2",
+						DeviceTypesCompatible: []string{"device1"},
+					},
+				},
+			},
+			InputFilter: &model.ReleaseOrImageFilter{
+				Name:      "test-image",
+				ExactName: true,
+			},
+			ExpectedCount:  1,
+			ExpectedImages: []string{"1"},
+		},
+		{
+			Name: "exact description match",
+			InputImages: []interface{}{
+				model.Image{
+					Id: "1",
+					ImageMeta: &model.ImageMeta{
+						Description: "test description",
+					},
+					ArtifactMeta: &model.ArtifactMeta{
+						Name:                  "test-image",
+						DeviceTypesCompatible: []string{"device1"},
+					},
+				},
+				model.Image{
+					Id: "2",
+					ImageMeta: &model.ImageMeta{
+						Description: "test description extended",
+					},
+					ArtifactMeta: &model.ArtifactMeta{
+						Name:                  "test-image-2",
+						DeviceTypesCompatible: []string{"device1"},
+					},
+				},
+			},
+			InputFilter: &model.ReleaseOrImageFilter{
+				Description:      "test description",
+				ExactDescription: true,
+			},
+			ExpectedCount:  1,
+			ExpectedImages: []string{"1"},
+		},
+		{
+			Name: "exact device type match",
+			InputImages: []interface{}{
+				model.Image{
+					Id: "1",
+					ArtifactMeta: &model.ArtifactMeta{
+						Name:                  "test-image",
+						DeviceTypesCompatible: []string{"raspberrypi4"},
+					},
+				},
+				model.Image{
+					Id: "2",
+					ArtifactMeta: &model.ArtifactMeta{
+						Name:                  "test-image-2",
+						DeviceTypesCompatible: []string{"raspberrypi4-64"},
+					},
+				},
+			},
+			InputFilter: &model.ReleaseOrImageFilter{
+				DeviceType:      "raspberrypi4",
+				ExactDeviceType: true,
+			},
+			ExpectedCount:  1,
+			ExpectedImages: []string{"1"},
+		},
+		{
+			Name: "non-exact matches (regex)",
+			InputImages: []interface{}{
+				model.Image{
+					Id: "1",
+					ArtifactMeta: &model.ArtifactMeta{
+						Name:                  "test-image",
+						DeviceTypesCompatible: []string{"raspberrypi4"},
+					},
+				},
+				model.Image{
+					Id: "2",
+					ArtifactMeta: &model.ArtifactMeta{
+						Name:                  "test-image-2",
+						DeviceTypesCompatible: []string{"raspberrypi4"},
+					},
+				},
+			},
+			InputFilter: &model.ReleaseOrImageFilter{
+				Name: "test-image",
+			},
+			ExpectedCount:  2,
+			ExpectedImages: []string{"1", "2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			db.Wipe()
+
+			client := db.Client()
+			store := NewDataStoreMongoWithClient(client)
+
+			ctx := context.Background()
+
+			collImg := client.Database(DatabaseName).Collection(CollectionImages)
+			if len(tc.InputImages) > 0 {
+				_, err := collImg.InsertMany(ctx, tc.InputImages)
+				assert.NoError(t, err)
+			}
+
+			images, count, err := store.ListImages(ctx, tc.InputFilter)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.ExpectedCount, count)
+			assert.Len(t, images, len(tc.ExpectedImages))
+
+			imageIDs := make([]string, len(images))
+			for i, img := range images {
+				imageIDs[i] = img.Id
+			}
+			assert.ElementsMatch(t, tc.ExpectedImages, imageIDs)
+		})
+	}
+}


### PR DESCRIPTION
When using the List Artifacts APIs to find artifacts by name, the
existing implementation only supports $regex search using the pattern
".*<name>.*". This is CPU intensive on large image collections, when the
user only needs an exact match. On an existing dataset with 60000
images, the existing $regex query took 421ms while the new exact_name
query took 9ms. This was benchmarked using both device_types and name
set. Also, the new exact match makes an index more effective.

Adds exact_name, exact_device_type, and exact_description boolean params
to the GET /artifacts and GET /artifacts/list APIs. For example,
/artifacts/list?name=123.t would match name="123.test" but
/artifacts/list?name=123.t&exact_name would not match.

Tested: Ran a local deployments instance hooked up to a dev mongodb
atlas instance. Used curl with exact_name and exact_device_type, tested
that inexact matches were not returned using the new exact_ params but
were returned without the exact_ params.